### PR TITLE
Add --selectedTables switch

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,6 +69,7 @@ func init() {
 	rootCmd.Flags().StringP(config.ConnectionStringKey, "c", "", "connection string that should be used")
 	rootCmd.Flags().StringP(config.SchemaKey, "s", "", "schema that should be used")
 	rootCmd.Flags().StringP(config.OutputFileNameKey, "o", "result.mmd", "output file name")
+	rootCmd.Flags().StringSlice(config.SelectedTablesKey, []string{""}, "tables to include")
 
 	bindFlagToViper(config.ShowAllConstraintsKey)
 	bindFlagToViper(config.UseAllTablesKey)
@@ -78,6 +79,8 @@ func init() {
 	bindFlagToViper(config.ConnectionStringKey)
 	bindFlagToViper(config.SchemaKey)
 	bindFlagToViper(config.OutputFileNameKey)
+	bindFlagToViper(config.SelectedTablesKey)
+
 }
 
 func bindFlagToViper(key string) {


### PR DESCRIPTION
ERD generation in CI/CD is a pretty common workflow, and some projects understandably will not want to introduce a memerd configuration file to their projects simply to specify which tables to include in the diagram. 

This simple modification exposes the `--selectedTables` switch, so it's not necessary to create a configuration file to select tables for diagram inclusion. 