### PR TITLE
Enable the copy-button

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,9 @@ the [Changelog](https://github.com/KarnerTh/mermerd/blob/master/changelog.md)
 </ul>
 
 ## Installation
-`go install github.com/KarnerTh/mermerd@latest`
+```sh
+go install github.com/KarnerTh/mermerd@latest
+```
 
 or
 


### PR DESCRIPTION
Proposed formatting enables the copy-button which appears in the top right corner of the copy widget. Which makes copy'n pasting the code fragment much easier.
<img width="1057" alt="image" src="https://user-images.githubusercontent.com/58164/181620284-8dc9fd93-8aab-4136-9c05-930bd6b5edff.png">
