### PR TITLE
GetColumns updated for is_primary and is_foreign 

### DIFF
--- a/database/mssql.go
+++ b/database/mssql.go
@@ -81,13 +81,13 @@ func (c *mssqlConnector) GetColumns(tableName string) ([]ColumnResult, error) {
 	rows, err := c.db.Query(`
 		select c.column_name,
 			   c.data_type,
-			   (select count(*)
+			   (select count(*) > 0
 				from information_schema.key_column_usage cu
 						 left join information_schema.table_constraints tc on tc.constraint_name = cu.constraint_name
 				where cu.column_name = c.column_name
 				  and cu.table_name = c.table_name
 				  and tc.constraint_type = 'PRIMARY KEY') as is_primary,
-			   (select count(*)
+			   (select count(*) > 0
 				from information_schema.key_column_usage cu
 						 left join information_schema.table_constraints tc on tc.constraint_name = cu.constraint_name
 				where cu.column_name = c.column_name

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -81,12 +81,12 @@ func (c *mySqlConnector) GetColumns(tableName string) ([]ColumnResult, error) {
 	rows, err := c.db.Query(`
 		select c.column_name,
 			   c.data_type,
-			   (select count(*)
+			   (select count(*) > 0
 				from information_schema.KEY_COLUMN_USAGE
 				where table_name = c.table_name
 				  and column_name = c.column_name
 				  and constraint_name = 'PRIMARY')        as is_primary,
-			   (select count(*)
+			   (select count(*) > 0
 				from information_schema.key_column_usage cu
 						 left join information_schema.table_constraints tc on tc.constraint_name = cu.constraint_name
 				where cu.column_name = c.column_name

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -81,13 +81,13 @@ func (c *postgresConnector) GetColumns(tableName string) ([]ColumnResult, error)
 	rows, err := c.db.Query(`
 		select c.column_name,
 			   c.data_type,
-			   (select count(*)
+			   (select count(*) > 0
 				from information_schema.key_column_usage cu
 						 left join information_schema.table_constraints tc on tc.constraint_name = cu.constraint_name
 				where cu.column_name = c.column_name
 				  and cu.table_name = c.table_name
 				  and tc.constraint_type = 'PRIMARY KEY') as is_primary,
-			   (select count(*)
+			   (select count(*) > 0
 				from information_schema.key_column_usage cu
 						 left join information_schema.table_constraints tc on tc.constraint_name = cu.constraint_name
 				where cu.column_name = c.column_name


### PR DESCRIPTION
- GetColumns Raw query corrected as the same column name can be referred in multiple primary and foreign keys
- Updated for database/postgres: database/mssql:GetColumns and database/mysql:GetColumns

fixes #24 