### PR TITLE
Multi schema support

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -103,7 +103,7 @@ func (a analyzer) GetSchemas(db database.Connector) ([]string, error) {
 func (a analyzer) GetTables(db database.Connector, selectedSchemas []string) ([]database.TableNameResult, error) {
 	if selectedTables := a.config.SelectedTables(); len(selectedTables) > 0 {
 		return util.Map2(selectedTables, func(value string) database.TableNameResult {
-			res, err := database.ParseTableName(value)
+			res, err := database.ParseTableName(value, selectedSchemas)
 			if err != nil {
 				logrus.Error("Could not parse table name", value)
 			}
@@ -137,7 +137,7 @@ func (a analyzer) GetTables(db database.Connector, selectedSchemas []string) ([]
 			return []database.TableNameResult{}, err
 		}
 		return util.Map2(surveyResult, func(value string) database.TableNameResult {
-			res, err := database.ParseTableName(value)
+			res, err := database.ParseTableName(value, selectedSchemas)
 			if err != nil {
 				logrus.Error("Could not parse table name", value)
 			}

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -142,7 +142,7 @@ func TestAnalyzer_GetTables(t *testing.T) {
 		analyzer, configMock, _, _ := getAnalyzerWithMocks()
 		connectorMock := mocks.Connector{}
 		configMock.On("SelectedTables").Return([]string{}).Once()
-		connectorMock.On("GetTables", []string{"validSchema"}).Return([]database.TableNameResult{{Schema: "validSchema", Name: "tableA"}, {Schema: "validSchema", Name: "tableB"}}, nil).Once()
+		connectorMock.On("GetTables", []string{"validSchema"}).Return([]database.TableDetail{{Schema: "validSchema", Name: "tableA"}, {Schema: "validSchema", Name: "tableB"}}, nil).Once()
 		configMock.On("UseAllTables").Return(true).Once()
 
 		// Act
@@ -162,7 +162,7 @@ func TestAnalyzer_GetTables(t *testing.T) {
 		analyzer, configMock, _, questionerMock := getAnalyzerWithMocks()
 		connectorMock := mocks.Connector{}
 		configMock.On("SelectedTables").Return([]string{}).Once()
-		connectorMock.On("GetTables", []string{"validSchema"}).Return([]database.TableNameResult{{Schema: "validSchema", Name: "tableA"}, {Schema: "validSchema", Name: "tableB"}}, nil).Once()
+		connectorMock.On("GetTables", []string{"validSchema"}).Return([]database.TableDetail{{Schema: "validSchema", Name: "tableA"}, {Schema: "validSchema", Name: "tableB"}}, nil).Once()
 		configMock.On("UseAllTables").Return(false).Once()
 		questionerMock.On("AskTableQuestion", []string{"validSchema.tableA", "validSchema.tableB"}).Return([]string{"validSchema.tableA"}, nil).Once()
 
@@ -190,7 +190,7 @@ func TestAnalyzer_Analyze(t *testing.T) {
 		connectorMock.On("Close").Return().Once()
 		configMock.On("Schemas").Return([]string{"validSchema"}).Once()
 		configMock.On("SelectedTables").Return([]string{"validSchema.tableA", "validSchema.tableB"}).Once()
-		connectorMock.On("GetColumns", database.TableNameResult{Schema: "validSchema", Name: "tableA"}).Return([]database.ColumnResult{
+		connectorMock.On("GetColumns", database.TableDetail{Schema: "validSchema", Name: "tableA"}).Return([]database.ColumnResult{
 			{
 				Name:     "fieldA",
 				DataType: "int",
@@ -200,7 +200,7 @@ func TestAnalyzer_Analyze(t *testing.T) {
 				DataType: "string",
 			},
 		}, nil).Once()
-		connectorMock.On("GetColumns", database.TableNameResult{Schema: "validSchema", Name: "tableB"}).Return([]database.ColumnResult{
+		connectorMock.On("GetColumns", database.TableDetail{Schema: "validSchema", Name: "tableB"}).Return([]database.ColumnResult{
 			{
 				Name:     "fieldC",
 				DataType: "int",
@@ -210,14 +210,14 @@ func TestAnalyzer_Analyze(t *testing.T) {
 				DataType: "string",
 			},
 		}, nil).Once()
-		connectorMock.On("GetConstraints", database.TableNameResult{Schema: "validSchema", Name: "tableA"}).Return([]database.ConstraintResult{{
+		connectorMock.On("GetConstraints", database.TableDetail{Schema: "validSchema", Name: "tableA"}).Return([]database.ConstraintResult{{
 			FkTable:        "tableA",
 			PkTable:        "tableB",
 			ConstraintName: "testConstraint",
 			IsPrimary:      false,
 			HasMultiplePK:  false,
 		}}, nil).Once()
-		connectorMock.On("GetConstraints", database.TableNameResult{Schema: "validSchema", Name: "tableB"}).Return([]database.ConstraintResult{{
+		connectorMock.On("GetConstraints", database.TableDetail{Schema: "validSchema", Name: "tableB"}).Return([]database.ConstraintResult{{
 			FkTable:        "tableA",
 			PkTable:        "tableB",
 			ConstraintName: "testConstraint",

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -65,11 +65,30 @@ func TestAnalyzer_GetSchema(t *testing.T) {
 		assert.ElementsMatch(t, []string{"configuredSchema"}, result)
 	})
 
+	t.Run("Use all available schema", func(t *testing.T) {
+		// Arrange
+		analyzer, configMock, _, _ := getAnalyzerWithMocks()
+		connectorMock := mocks.Connector{}
+		configMock.On("UseAllSchemas").Return(true).Once()
+		configMock.On("Schemas").Return([]string{}).Once()
+		connectorMock.On("GetSchemas").Return([]string{"schema1", "schema2"}, nil).Once()
+
+		// Act
+		result, err := analyzer.GetSchemas(&connectorMock)
+
+		// Assert
+		configMock.AssertExpectations(t)
+		connectorMock.AssertExpectations(t)
+		assert.Nil(t, err)
+		assert.ElementsMatch(t, []string{"schema1", "schema2"}, result)
+	})
+
 	t.Run("No schema available return error", func(t *testing.T) {
 		// Arrange
 		analyzer, configMock, _, _ := getAnalyzerWithMocks()
 		connectorMock := mocks.Connector{}
 		configMock.On("Schemas").Return([]string{}).Once()
+		configMock.On("UseAllSchemas").Return(false).Once()
 		connectorMock.On("GetSchemas").Return([]string{}, nil).Once()
 
 		// Act
@@ -87,6 +106,7 @@ func TestAnalyzer_GetSchema(t *testing.T) {
 		analyzer, configMock, _, _ := getAnalyzerWithMocks()
 		connectorMock := mocks.Connector{}
 		configMock.On("Schemas").Return([]string{}).Once()
+		configMock.On("UseAllSchemas").Return(false).Once()
 		connectorMock.On("GetSchemas").Return([]string{"onlyItem"}, nil).Once()
 
 		// Act
@@ -104,6 +124,7 @@ func TestAnalyzer_GetSchema(t *testing.T) {
 		analyzer, configMock, _, questionerMock := getAnalyzerWithMocks()
 		connectorMock := mocks.Connector{}
 		configMock.On("Schemas").Return([]string{}).Once()
+		configMock.On("UseAllSchemas").Return(false).Once()
 		connectorMock.On("GetSchemas").Return([]string{"first", "second"}, nil).Once()
 		questionerMock.On("AskSchemaQuestion", []string{"first", "second"}).Return([]string{"first"}, nil).Once()
 

--- a/analyzer/questioner.go
+++ b/analyzer/questioner.go
@@ -38,7 +38,7 @@ func (q questioner) AskConnectionQuestion(suggestions []string) (string, error) 
 func (q questioner) AskSchemaQuestion(schemas []string) ([]string, error) {
 	var result []string
 	question := &survey.MultiSelect{
-		Message: "Choose a schema:",
+		Message: "Choose schemas:",
 		Options: schemas,
 	}
 

--- a/analyzer/questioner.go
+++ b/analyzer/questioner.go
@@ -10,7 +10,7 @@ type questioner struct{}
 
 type Questioner interface {
 	AskConnectionQuestion(suggestions []string) (string, error)
-	AskSchemaQuestion(schemas []string) (string, error)
+	AskSchemaQuestion(schemas []string) ([]string, error)
 	AskTableQuestion(tables []string) ([]string, error)
 }
 
@@ -35,14 +35,14 @@ func (q questioner) AskConnectionQuestion(suggestions []string) (string, error) 
 	return os.ExpandEnv(result), nil
 }
 
-func (q questioner) AskSchemaQuestion(schemas []string) (string, error) {
-	var result string
-	question := &survey.Select{
+func (q questioner) AskSchemaQuestion(schemas []string) ([]string, error) {
+	var result []string
+	question := &survey.MultiSelect{
 		Message: "Choose a schema:",
 		Options: schemas,
 	}
 
-	err := survey.AskOne(question, &result)
+	err := survey.AskOne(question, &result, survey.WithValidator(survey.MinItems(1)))
 	return result, err
 }
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (after version 0.0
 ## [0.5.0] - 2022-12-xx
 ### Added
 - Support enum description ([Issue #15](https://github.com/KarnerTh/mermerd/issues/15))
+- Support multiple schemas ([Issue #23](https://github.com/KarnerTh/mermerd/issues/23))
 
 ## [0.4.1] - 2022-09-28
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (after version 0.0.5).
 
-## [0.5.0] - 2022-12-xx
+## [0.5.0] - 2022-12-28
 ### Added
 - Support enum description ([Issue #15](https://github.com/KarnerTh/mermerd/issues/15))
 - Support multiple schemas ([Issue #23](https://github.com/KarnerTh/mermerd/issues/23))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,6 +65,7 @@ func init() {
 	rootCmd.Flags().StringVar(&runConfig, "runConfig", "", "run configuration (replaces global configuration)")
 	rootCmd.Flags().Bool(config.ShowAllConstraintsKey, false, "show all constraints, even though the table of the resulting constraint was not selected")
 	rootCmd.Flags().Bool(config.UseAllTablesKey, false, "use all available tables")
+	rootCmd.Flags().Bool(config.UseAllSchemasKey, false, "use all available schemas")
 	rootCmd.Flags().Bool(config.DebugKey, false, "show debug logs")
 	rootCmd.Flags().Bool(config.OmitConstraintLabelsKey, false, "omit the constraint labels")
 	rootCmd.Flags().Bool(config.OmitAttributeKeysKey, false, "omit the attribute keys (PK, FK)")
@@ -77,6 +78,7 @@ func init() {
 
 	bindFlagToViper(config.ShowAllConstraintsKey)
 	bindFlagToViper(config.UseAllTablesKey)
+	bindFlagToViper(config.UseAllSchemasKey)
 	bindFlagToViper(config.DebugKey)
 	bindFlagToViper(config.OmitConstraintLabelsKey)
 	bindFlagToViper(config.OmitAttributeKeysKey)

--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ type config struct{}
 type MermerdConfig interface {
 	ShowAllConstraints() bool
 	UseAllTables() bool
-	Schema() string
+	Schemas() []string
 	ConnectionString() string
 	OutputFileName() string
 	ConnectionStringSuggestions() []string
@@ -46,8 +46,8 @@ func (c config) UseAllTables() bool {
 	return viper.GetBool(UseAllTablesKey)
 }
 
-func (c config) Schema() string {
-	return viper.GetString(SchemaKey)
+func (c config) Schemas() []string {
+	return viper.GetStringSlice(SchemaKey)
 }
 
 func (c config) ConnectionString() string {

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ const (
 	OmitConstraintLabelsKey        = "omitConstraintLabels"
 	OmitAttributeKeysKey           = "omitAttributeKeys"
 	ShowEnumValuesKey              = "showEnumValues"
+	UseAllSchemasKey               = "useAllSchemas"
 )
 
 type config struct{}
@@ -32,6 +33,7 @@ type MermerdConfig interface {
 	OmitConstraintLabels() bool
 	OmitAttributeKeys() bool
 	ShowEnumValues() bool
+	UseAllSchemas() bool
 }
 
 func NewConfig() MermerdConfig {
@@ -84,4 +86,8 @@ func (c config) OmitAttributeKeys() bool {
 
 func (c config) ShowEnumValues() bool {
 	return viper.GetBool(ShowEnumValuesKey)
+}
+
+func (c config) UseAllSchemas() bool {
+	return viper.GetBool(UseAllSchemasKey)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -39,7 +39,7 @@ connectionStringSuggestions:
 	// Assert
 	assert.Nil(t, err)
 	assert.Equal(t, "connectionStringExample", config.ConnectionString())
-	assert.Equal(t, "public", config.Schema())
+	assert.ElementsMatch(t, []string{"public"}, config.Schemas())
 	assert.Equal(t, false, config.UseAllTables())
 	assert.ElementsMatch(t, []string{"city", "customer"}, config.SelectedTables())
 	assert.Equal(t, true, config.ShowAllConstraints())

--- a/database/connector.go
+++ b/database/connector.go
@@ -13,7 +13,7 @@ type Connector interface {
 	Close()
 	GetDbType() DbType
 	GetSchemas() ([]string, error)
-	GetTables(schemaName string) ([]string, error)
-	GetColumns(tableName string) ([]ColumnResult, error)
-	GetConstraints(tableName string) ([]ConstraintResult, error)
+	GetTables(schemaNames []string) ([]TableNameResult, error)
+	GetColumns(tableName TableNameResult) ([]ColumnResult, error)
+	GetConstraints(tableName TableNameResult) ([]ConstraintResult, error)
 }

--- a/database/connector.go
+++ b/database/connector.go
@@ -13,7 +13,7 @@ type Connector interface {
 	Close()
 	GetDbType() DbType
 	GetSchemas() ([]string, error)
-	GetTables(schemaNames []string) ([]TableNameResult, error)
-	GetColumns(tableName TableNameResult) ([]ColumnResult, error)
-	GetConstraints(tableName TableNameResult) ([]ConstraintResult, error)
+	GetTables(schemaNames []string) ([]TableDetail, error)
+	GetColumns(tableName TableDetail) ([]ColumnResult, error)
+	GetConstraints(tableName TableDetail) ([]ConstraintResult, error)
 }

--- a/database/database_integration_test.go
+++ b/database/database_integration_test.go
@@ -34,22 +34,22 @@ func TestDatabaseIntegrations(t *testing.T) {
 	testCases := []struct {
 		dbType           DbType
 		connectionString string
-		schema           string
+		schema           []string
 	}{
 		{
 			dbType:           Postgres,
 			connectionString: testConnectionPostgres.connectionString,
-			schema:           testConnectionPostgres.schema,
+			schema:           []string{testConnectionPostgres.schema},
 		},
 		{
 			dbType:           MySql,
 			connectionString: testConnectionMySql.connectionString,
-			schema:           testConnectionMySql.schema,
+			schema:           []string{testConnectionMySql.schema},
 		},
 		{
 			dbType:           MsSql,
 			connectionString: testConnectionMsSql.connectionString,
-			schema:           testConnectionMsSql.schema,
+			schema:           []string{testConnectionMsSql.schema},
 		},
 	}
 
@@ -152,7 +152,7 @@ func TestDatabaseIntegrations(t *testing.T) {
 				for index, testCase := range testCases {
 					t.Run(fmt.Sprintf("run #%d", index), func(t *testing.T) {
 						// Arrange
-						tableName := testCase.tableName
+						tableName := TableNameResult{Name: testCase.tableName}
 						var columnResult []columnTestResult
 
 						// Act
@@ -178,7 +178,7 @@ func TestDatabaseIntegrations(t *testing.T) {
 
 				t.Run("One-to-one relation", func(t *testing.T) {
 					// Arrange
-					tableName := "article_detail"
+					tableName := TableNameResult{Name: "article_detail"}
 
 					// Act
 					constraintResults, err := connector.GetConstraints(tableName)
@@ -193,7 +193,7 @@ func TestDatabaseIntegrations(t *testing.T) {
 
 				t.Run("Many-to-one relation #1", func(t *testing.T) {
 					// Arrange
-					tableName := "article_comment"
+					tableName := TableNameResult{Name: "article_comment"}
 
 					// Act
 					constraintResults, err := connector.GetConstraints(tableName)
@@ -208,8 +208,8 @@ func TestDatabaseIntegrations(t *testing.T) {
 
 				t.Run("Many-to-one relation #2", func(t *testing.T) {
 					// Arrange
-					pkTableName := "article"
-					fkTableName := "article_label"
+					pkTableName := TableNameResult{Name: "article"}
+					fkTableName := TableNameResult{Name: "article_label"}
 
 					// Act
 					constraintResults, err := connector.GetConstraints(pkTableName)
@@ -218,7 +218,7 @@ func TestDatabaseIntegrations(t *testing.T) {
 					assert.Nil(t, err)
 					var constraint *ConstraintResult
 					for _, item := range constraintResults {
-						if item.FkTable == fkTableName {
+						if item.FkTable == fkTableName.Name {
 							constraint = &item
 							break
 						}
@@ -231,7 +231,7 @@ func TestDatabaseIntegrations(t *testing.T) {
 				// Multiple primary keys (https://github.com/KarnerTh/mermerd/issues/8)
 				t.Run("Test 1 (Issue #8)", func(t *testing.T) {
 					// Arrange
-					pkTableName := "test_1_b"
+					pkTableName := TableNameResult{Name: "test_1_b"}
 
 					// Act
 					constraintResults, err := connector.GetConstraints(pkTableName)

--- a/database/database_integration_test.go
+++ b/database/database_integration_test.go
@@ -115,7 +115,7 @@ func TestDatabaseIntegrations(t *testing.T) {
 
 			t.Run("GetColumns", func(t *testing.T) {
 				connector := getConnectionAndConnect(t)
-				testCases := []struct {
+				subTestCases := []struct {
 					tableName       string
 					expectedColumns []columnTestResult
 				}{
@@ -150,10 +150,10 @@ func TestDatabaseIntegrations(t *testing.T) {
 					}},
 				}
 
-				for index, testCase := range testCases {
+				for index, subTestCase := range subTestCases {
 					t.Run(fmt.Sprintf("run #%d", index), func(t *testing.T) {
 						// Arrange
-						tableName := TableNameResult{Name: testCase.tableName}
+						tableName := TableNameResult{Schema: testCase.schema[0], Name: subTestCase.tableName}
 						var columnResult []columnTestResult
 
 						// Act
@@ -169,7 +169,7 @@ func TestDatabaseIntegrations(t *testing.T) {
 						}
 
 						assert.Nil(t, err)
-						assert.ElementsMatch(t, testCase.expectedColumns, columnResult)
+						assert.ElementsMatch(t, subTestCase.expectedColumns, columnResult)
 					})
 				}
 			})
@@ -179,7 +179,7 @@ func TestDatabaseIntegrations(t *testing.T) {
 
 				t.Run("One-to-one relation", func(t *testing.T) {
 					// Arrange
-					tableName := TableNameResult{Name: "article_detail"}
+					tableName := TableNameResult{Schema: testCase.schema[0], Name: "article_detail"}
 
 					// Act
 					constraintResults, err := connector.GetConstraints(tableName)
@@ -194,7 +194,7 @@ func TestDatabaseIntegrations(t *testing.T) {
 
 				t.Run("Many-to-one relation #1", func(t *testing.T) {
 					// Arrange
-					tableName := TableNameResult{Name: "article_comment"}
+					tableName := TableNameResult{Schema: testCase.schema[0], Name: "article_comment"}
 
 					// Act
 					constraintResults, err := connector.GetConstraints(tableName)
@@ -209,8 +209,8 @@ func TestDatabaseIntegrations(t *testing.T) {
 
 				t.Run("Many-to-one relation #2", func(t *testing.T) {
 					// Arrange
-					pkTableName := TableNameResult{Name: "article"}
-					fkTableName := TableNameResult{Name: "article_label"}
+					pkTableName := TableNameResult{Schema: testCase.schema[0], Name: "article"}
+					fkTableName := TableNameResult{Schema: testCase.schema[0], Name: "article_label"}
 
 					// Act
 					constraintResults, err := connector.GetConstraints(pkTableName)
@@ -230,9 +230,9 @@ func TestDatabaseIntegrations(t *testing.T) {
 				})
 
 				// Multiple primary keys (https://github.com/KarnerTh/mermerd/issues/8)
-				t.Run("Test 1 (Issue #8)", func(t *testing.T) {
+				t.Run("Multiple primary keys (Issue #8)", func(t *testing.T) {
 					// Arrange
-					pkTableName := TableNameResult{Name: "test_1_b"}
+					pkTableName := TableNameResult{Schema: testCase.schema[0], Name: "test_1_b"}
 
 					// Act
 					constraintResults, err := connector.GetConstraints(pkTableName)
@@ -249,6 +249,10 @@ func TestDatabaseIntegrations(t *testing.T) {
 					assert.Equal(t, constraintResults[1].ColumnName, "bid")
 				})
 			})
+
+			// t.Run("Multiple schemas (Issue #23)", func(t *testing.T) {
+			//
+			// })
 		})
 	}
 }

--- a/database/database_integration_test.go
+++ b/database/database_integration_test.go
@@ -98,7 +98,7 @@ func TestDatabaseIntegrations(t *testing.T) {
 				tables, err := connector.GetTables([]string{schema})
 
 				// Assert
-				expectedResult := []TableNameResult{
+				expectedResult := []TableDetail{
 					{Schema: schema, Name: "article"},
 					{Schema: schema, Name: "article_detail"},
 					{Schema: schema, Name: "article_comment"},
@@ -153,7 +153,7 @@ func TestDatabaseIntegrations(t *testing.T) {
 				for index, subTestCase := range subTestCases {
 					t.Run(fmt.Sprintf("run #%d", index), func(t *testing.T) {
 						// Arrange
-						tableName := TableNameResult{Schema: testCase.schema, Name: subTestCase.tableName}
+						tableName := TableDetail{Schema: testCase.schema, Name: subTestCase.tableName}
 						var columnResult []columnTestResult
 
 						// Act
@@ -179,7 +179,7 @@ func TestDatabaseIntegrations(t *testing.T) {
 
 				t.Run("One-to-one relation", func(t *testing.T) {
 					// Arrange
-					tableName := TableNameResult{Schema: testCase.schema, Name: "article_detail"}
+					tableName := TableDetail{Schema: testCase.schema, Name: "article_detail"}
 
 					// Act
 					constraintResults, err := connector.GetConstraints(tableName)
@@ -194,7 +194,7 @@ func TestDatabaseIntegrations(t *testing.T) {
 
 				t.Run("Many-to-one relation #1", func(t *testing.T) {
 					// Arrange
-					tableName := TableNameResult{Schema: testCase.schema, Name: "article_comment"}
+					tableName := TableDetail{Schema: testCase.schema, Name: "article_comment"}
 
 					// Act
 					constraintResults, err := connector.GetConstraints(tableName)
@@ -209,8 +209,8 @@ func TestDatabaseIntegrations(t *testing.T) {
 
 				t.Run("Many-to-one relation #2", func(t *testing.T) {
 					// Arrange
-					pkTableName := TableNameResult{Schema: testCase.schema, Name: "article"}
-					fkTableName := TableNameResult{Schema: testCase.schema, Name: "article_label"}
+					pkTableName := TableDetail{Schema: testCase.schema, Name: "article"}
+					fkTableName := TableDetail{Schema: testCase.schema, Name: "article_label"}
 
 					// Act
 					constraintResults, err := connector.GetConstraints(pkTableName)
@@ -232,7 +232,7 @@ func TestDatabaseIntegrations(t *testing.T) {
 				// Multiple primary keys (https://github.com/KarnerTh/mermerd/issues/8)
 				t.Run("Multiple primary keys (Issue #8)", func(t *testing.T) {
 					// Arrange
-					pkTableName := TableNameResult{Schema: testCase.schema, Name: "test_1_b"}
+					pkTableName := TableDetail{Schema: testCase.schema, Name: "test_1_b"}
 
 					// Act
 					constraintResults, err := connector.GetConstraints(pkTableName)
@@ -262,7 +262,7 @@ func TestDatabaseIntegrations(t *testing.T) {
 					tables, err := connector.GetTables(schemas)
 
 					// Assert
-					expectedResult := []TableNameResult{
+					expectedResult := []TableDetail{
 						{Schema: testCase.schema, Name: "article"},
 						{Schema: testCase.schema, Name: "article_detail"},
 						{Schema: testCase.schema, Name: "article_comment"},
@@ -281,7 +281,7 @@ func TestDatabaseIntegrations(t *testing.T) {
 
 				t.Run("GetCrossSchemaConstraints", func(t *testing.T) {
 					// Arrange
-					tableName := TableNameResult{Schema: "other_db", Name: "test_3_b"}
+					tableName := TableDetail{Schema: "other_db", Name: "test_3_b"}
 
 					// Act
 					constraintResults, err := connector.GetConstraints(tableName)

--- a/database/database_integration_test.go
+++ b/database/database_integration_test.go
@@ -2,9 +2,9 @@ package database
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -98,15 +98,16 @@ func TestDatabaseIntegrations(t *testing.T) {
 				tables, err := connector.GetTables(schema)
 
 				// Assert
-				expectedResult := []string{
-					"article",
-					"article_detail",
-					"article_comment",
-					"label",
-					"article_label",
-					"test_1_a",
-					"test_1_b",
-					"test_2_enum",
+				expectedResult := []TableNameResult{
+					{Schema: schema[0], Name: "article"},
+					{Schema: schema[0], Name: "article_detail"},
+					{Schema: schema[0], Name: "article_comment"},
+					{Schema: schema[0], Name: "label"},
+					{Schema: schema[0], Name: "article_label"},
+					{Schema: schema[0], Name: "test_1_a"},
+					{Schema: schema[0], Name: "test_1_b"},
+					{Schema: schema[0], Name: "test_2_enum"},
+					{Schema: schema[0], Name: "test_3_a"},
 				}
 				assert.Nil(t, err)
 				assert.ElementsMatch(t, expectedResult, tables)

--- a/database/database_integration_test.go
+++ b/database/database_integration_test.go
@@ -34,22 +34,22 @@ func TestDatabaseIntegrations(t *testing.T) {
 	testCases := []struct {
 		dbType           DbType
 		connectionString string
-		schema           []string
+		schema           string
 	}{
 		{
 			dbType:           Postgres,
 			connectionString: testConnectionPostgres.connectionString,
-			schema:           []string{testConnectionPostgres.schema},
+			schema:           testConnectionPostgres.schema,
 		},
 		{
 			dbType:           MySql,
 			connectionString: testConnectionMySql.connectionString,
-			schema:           []string{testConnectionMySql.schema},
+			schema:           testConnectionMySql.schema,
 		},
 		{
 			dbType:           MsSql,
 			connectionString: testConnectionMsSql.connectionString,
-			schema:           []string{testConnectionMsSql.schema},
+			schema:           testConnectionMsSql.schema,
 		},
 	}
 
@@ -95,19 +95,19 @@ func TestDatabaseIntegrations(t *testing.T) {
 				schema := testCase.schema
 
 				// Act
-				tables, err := connector.GetTables(schema)
+				tables, err := connector.GetTables([]string{schema})
 
 				// Assert
 				expectedResult := []TableNameResult{
-					{Schema: schema[0], Name: "article"},
-					{Schema: schema[0], Name: "article_detail"},
-					{Schema: schema[0], Name: "article_comment"},
-					{Schema: schema[0], Name: "label"},
-					{Schema: schema[0], Name: "article_label"},
-					{Schema: schema[0], Name: "test_1_a"},
-					{Schema: schema[0], Name: "test_1_b"},
-					{Schema: schema[0], Name: "test_2_enum"},
-					{Schema: schema[0], Name: "test_3_a"},
+					{Schema: schema, Name: "article"},
+					{Schema: schema, Name: "article_detail"},
+					{Schema: schema, Name: "article_comment"},
+					{Schema: schema, Name: "label"},
+					{Schema: schema, Name: "article_label"},
+					{Schema: schema, Name: "test_1_a"},
+					{Schema: schema, Name: "test_1_b"},
+					{Schema: schema, Name: "test_2_enum"},
+					{Schema: schema, Name: "test_3_a"},
 				}
 				assert.Nil(t, err)
 				assert.ElementsMatch(t, expectedResult, tables)
@@ -153,7 +153,7 @@ func TestDatabaseIntegrations(t *testing.T) {
 				for index, subTestCase := range subTestCases {
 					t.Run(fmt.Sprintf("run #%d", index), func(t *testing.T) {
 						// Arrange
-						tableName := TableNameResult{Schema: testCase.schema[0], Name: subTestCase.tableName}
+						tableName := TableNameResult{Schema: testCase.schema, Name: subTestCase.tableName}
 						var columnResult []columnTestResult
 
 						// Act
@@ -179,7 +179,7 @@ func TestDatabaseIntegrations(t *testing.T) {
 
 				t.Run("One-to-one relation", func(t *testing.T) {
 					// Arrange
-					tableName := TableNameResult{Schema: testCase.schema[0], Name: "article_detail"}
+					tableName := TableNameResult{Schema: testCase.schema, Name: "article_detail"}
 
 					// Act
 					constraintResults, err := connector.GetConstraints(tableName)
@@ -194,7 +194,7 @@ func TestDatabaseIntegrations(t *testing.T) {
 
 				t.Run("Many-to-one relation #1", func(t *testing.T) {
 					// Arrange
-					tableName := TableNameResult{Schema: testCase.schema[0], Name: "article_comment"}
+					tableName := TableNameResult{Schema: testCase.schema, Name: "article_comment"}
 
 					// Act
 					constraintResults, err := connector.GetConstraints(tableName)
@@ -209,8 +209,8 @@ func TestDatabaseIntegrations(t *testing.T) {
 
 				t.Run("Many-to-one relation #2", func(t *testing.T) {
 					// Arrange
-					pkTableName := TableNameResult{Schema: testCase.schema[0], Name: "article"}
-					fkTableName := TableNameResult{Schema: testCase.schema[0], Name: "article_label"}
+					pkTableName := TableNameResult{Schema: testCase.schema, Name: "article"}
+					fkTableName := TableNameResult{Schema: testCase.schema, Name: "article_label"}
 
 					// Act
 					constraintResults, err := connector.GetConstraints(pkTableName)
@@ -232,7 +232,7 @@ func TestDatabaseIntegrations(t *testing.T) {
 				// Multiple primary keys (https://github.com/KarnerTh/mermerd/issues/8)
 				t.Run("Multiple primary keys (Issue #8)", func(t *testing.T) {
 					// Arrange
-					pkTableName := TableNameResult{Schema: testCase.schema[0], Name: "test_1_b"}
+					pkTableName := TableNameResult{Schema: testCase.schema, Name: "test_1_b"}
 
 					// Act
 					constraintResults, err := connector.GetConstraints(pkTableName)

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -54,7 +54,7 @@ func (c *mySqlConnector) GetSchemas() ([]string, error) {
 	return schemas, nil
 }
 
-func (c *mySqlConnector) GetTables(schemaNames []string) ([]TableNameResult, error) {
+func (c *mySqlConnector) GetTables(schemaNames []string) ([]TableDetail, error) {
 	args := make([]any, len(schemaNames))
 	for i, schemaName := range schemaNames {
 		args[i] = schemaName
@@ -69,9 +69,9 @@ func (c *mySqlConnector) GetTables(schemaNames []string) ([]TableNameResult, err
 		return nil, err
 	}
 
-	var tables []TableNameResult
+	var tables []TableDetail
 	for rows.Next() {
-		var table TableNameResult
+		var table TableDetail
 		if err = rows.Scan(&table.Schema, &table.Name); err != nil {
 			return nil, err
 		}
@@ -84,7 +84,7 @@ func (c *mySqlConnector) GetTables(schemaNames []string) ([]TableNameResult, err
 	return tables, nil
 }
 
-func (c *mySqlConnector) GetColumns(tableName TableNameResult) ([]ColumnResult, error) {
+func (c *mySqlConnector) GetColumns(tableName TableDetail) ([]ColumnResult, error) {
 	rows, err := c.db.Query(`
 		select c.column_name,
 			   c.data_type,
@@ -124,7 +124,7 @@ func (c *mySqlConnector) GetColumns(tableName TableNameResult) ([]ColumnResult, 
 	return columns, nil
 }
 
-func (c *mySqlConnector) GetConstraints(tableName TableNameResult) ([]ConstraintResult, error) {
+func (c *mySqlConnector) GetConstraints(tableName TableDetail) ([]ConstraintResult, error) {
 	rows, err := c.db.Query(`
 		select c.TABLE_NAME,
 			   c.REFERENCED_TABLE_NAME,

--- a/database/mysql_test.go
+++ b/database/mysql_test.go
@@ -21,7 +21,7 @@ func TestMysqlEnums(t *testing.T) {
 		logrus.Error(err)
 		t.FailNow()
 	}
-	columns, err := connector.GetColumns(TableNameResult{Schema: "mermerd_test", Name: "test_2_enum"})
+	columns, err := connector.GetColumns(TableDetail{Schema: "mermerd_test", Name: "test_2_enum"})
 
 	// Assert
 	for _, column := range columns {

--- a/database/mysql_test.go
+++ b/database/mysql_test.go
@@ -21,7 +21,7 @@ func TestMysqlEnums(t *testing.T) {
 		logrus.Error(err)
 		t.FailNow()
 	}
-	columns, err := connector.GetColumns("test_2_enum")
+  columns, err := connector.GetColumns(TableNameResult{Name: "test_2_enum"})
 
 	// Assert
 	for _, column := range columns {

--- a/database/mysql_test.go
+++ b/database/mysql_test.go
@@ -21,7 +21,7 @@ func TestMysqlEnums(t *testing.T) {
 		logrus.Error(err)
 		t.FailNow()
 	}
-  columns, err := connector.GetColumns(TableNameResult{Name: "test_2_enum"})
+	columns, err := connector.GetColumns(TableNameResult{Schema: "mermerd_test", Name: "test_2_enum"})
 
 	// Assert
 	for _, column := range columns {

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -55,13 +55,12 @@ func (c *postgresConnector) GetSchemas() ([]string, error) {
 }
 
 func (c *postgresConnector) GetTables(schemaNames []string) ([]TableNameResult, error) {
-	// possible sql injection
-	schemaSearch := strings.Join(schemaNames, ",")
+	schemaSearch := "{" + strings.Join(schemaNames, ",") + "}"
 	rows, err := c.db.Query(`
 		select table_schema, table_name
 		from information_schema.tables
 		where table_type = 'BASE TABLE'
-		  and table_schema in ($1)
+    and table_schema = ANY($1::varchar[])
 		`, schemaSearch)
 	if err != nil {
 		return nil, err

--- a/database/postgres_test.go
+++ b/database/postgres_test.go
@@ -21,7 +21,7 @@ func TestPostgresEnums(t *testing.T) {
 		logrus.Error(err)
 		t.FailNow()
 	}
-  columns, err := connector.GetColumns(TableNameResult{Schema: "public", Name: "test_2_enum"})
+  columns, err := connector.GetColumns(TableDetail{Schema: "public", Name: "test_2_enum"})
 
 	// Assert
 	for _, column := range columns {

--- a/database/postgres_test.go
+++ b/database/postgres_test.go
@@ -21,7 +21,7 @@ func TestPostgresEnums(t *testing.T) {
 		logrus.Error(err)
 		t.FailNow()
 	}
-	columns, err := connector.GetColumns("test_2_enum")
+  columns, err := connector.GetColumns(TableNameResult{Name: "test_2_enum"})
 
 	// Assert
 	for _, column := range columns {

--- a/database/postgres_test.go
+++ b/database/postgres_test.go
@@ -21,7 +21,7 @@ func TestPostgresEnums(t *testing.T) {
 		logrus.Error(err)
 		t.FailNow()
 	}
-  columns, err := connector.GetColumns(TableNameResult{Name: "test_2_enum"})
+  columns, err := connector.GetColumns(TableNameResult{Schema: "public", Name: "test_2_enum"})
 
 	// Assert
 	for _, column := range columns {

--- a/database/result.go
+++ b/database/result.go
@@ -5,9 +5,14 @@ type Result struct {
 }
 
 type TableResult struct {
-	TableName   string
+	TableName   TableNameResult
 	Columns     []ColumnResult
 	Constraints ConstraintResultList
+}
+
+type TableNameResult struct {
+	Schema string
+	Name   string
 }
 
 type ColumnResult struct {

--- a/database/result.go
+++ b/database/result.go
@@ -5,12 +5,12 @@ type Result struct {
 }
 
 type TableResult struct {
-	TableName   TableNameResult
+	Table       TableDetail
 	Columns     []ColumnResult
 	Constraints ConstraintResultList
 }
 
-type TableNameResult struct {
+type TableDetail struct {
 	Schema string
 	Name   string
 }

--- a/database/table_name_util.go
+++ b/database/table_name_util.go
@@ -5,20 +5,20 @@ import (
 	"strings"
 )
 
-func ParseTableName(value string, selectedSchemas []string) (TableNameResult, error) {
+func ParseTableName(value string, selectedSchemas []string) (TableDetail, error) {
 	parts := strings.Split(value, ".")
 
 	if len(parts) == 1 {
 		if len(selectedSchemas) != 1 {
-			return TableNameResult{}, errors.New("Could not parse table name")
+			return TableDetail{}, errors.New("If table names do not specify the schema, exactly one selected schema should be present")
 		}
 
-		return TableNameResult{Schema: selectedSchemas[0], Name: parts[0]}, nil
+		return TableDetail{Schema: selectedSchemas[0], Name: parts[0]}, nil
 	}
 
 	if len(parts) == 2 {
-		return TableNameResult{Schema: parts[0], Name: parts[1]}, nil
+		return TableDetail{Schema: parts[0], Name: parts[1]}, nil
 	}
 
-	return TableNameResult{}, errors.New("Could not parse table name")
+	return TableDetail{}, errors.New("Could not parse table name")
 }

--- a/database/table_name_util.go
+++ b/database/table_name_util.go
@@ -5,11 +5,15 @@ import (
 	"strings"
 )
 
-func ParseTableName(value string) (TableNameResult, error) {
+func ParseTableName(value string, selectedSchemas []string) (TableNameResult, error) {
 	parts := strings.Split(value, ".")
 
 	if len(parts) == 1 {
-		return TableNameResult{Schema: "", Name: parts[0]}, nil
+		if len(selectedSchemas) != 1 {
+			return TableNameResult{}, errors.New("Could not parse table name")
+		}
+
+		return TableNameResult{Schema: selectedSchemas[0], Name: parts[0]}, nil
 	}
 
 	if len(parts) == 2 {

--- a/database/table_name_util.go
+++ b/database/table_name_util.go
@@ -1,0 +1,20 @@
+package database
+
+import (
+	"errors"
+	"strings"
+)
+
+func ParseTableName(value string) (TableNameResult, error) {
+	parts := strings.Split(value, ".")
+
+	if len(parts) == 1 {
+		return TableNameResult{Schema: "", Name: parts[0]}, nil
+	}
+
+	if len(parts) == 2 {
+		return TableNameResult{Schema: parts[0], Name: parts[1]}, nil
+	}
+
+	return TableNameResult{}, errors.New("Could not parse table name")
+}

--- a/database/value_sanitizer.go
+++ b/database/value_sanitizer.go
@@ -8,7 +8,7 @@ import (
 func SanitizeValue(value string) string {
 	result := strings.ReplaceAll(value, " ", "_")
 
-	reg := regexp.MustCompile("[^a-zA-Z0-9_-]+")
+	reg := regexp.MustCompile("[^a-zA-Z0-9_.-]+")
 	result = reg.ReplaceAllString(result, "")
 
 	return result

--- a/database/value_sanitizer_test.go
+++ b/database/value_sanitizer_test.go
@@ -16,6 +16,7 @@ func TestSanitizeValue(t *testing.T) {
 		{inputValue: "numbers are allowed 7", expectedResult: "numbers_are_allowed_7"},
 		{inputValue: "valid_stays_valid", expectedResult: "valid_stays_valid"},
 		{inputValue: "valid-stays-valid", expectedResult: "valid-stays-valid"},
+		{inputValue: "dots.are.allowed", expectedResult: "dots.are.allowed"},
 		{inputValue: "symbols_$_are_&_not_§_allowed", expectedResult: "symbols__are__not__allowed"},
 		{inputValue: "also: not allowed", expectedResult: "also_not_allowed"},
 	}

--- a/diagram/diagram.go
+++ b/diagram/diagram.go
@@ -68,7 +68,7 @@ func (d diagram) Create(result *database.Result) error {
 		}
 
 		tableData[tableIndex] = ErdTableData{
-			Name:    table.TableName.Name,
+			Name:    table.Table.Name,
 			Columns: columnData,
 		}
 	}

--- a/diagram/diagram.go
+++ b/diagram/diagram.go
@@ -68,7 +68,7 @@ func (d diagram) Create(result *database.Result) error {
 		}
 
 		tableData[tableIndex] = ErdTableData{
-			Name:    table.TableName,
+			Name:    table.TableName.Name,
 			Columns: columnData,
 		}
 	}

--- a/exampleRunConfig.yaml
+++ b/exampleRunConfig.yaml
@@ -1,5 +1,8 @@
 # Connection properties
 connectionString: "postgresql://user:password@localhost:5432/mermerd_test"
+
+# Define what tables should be used
+#useAllSchemas: true
 schema: 
   - "public"
   - "other_db"

--- a/exampleRunConfig.yaml
+++ b/exampleRunConfig.yaml
@@ -1,6 +1,7 @@
 # Connection properties
 connectionString: "postgresql://user:password@localhost:5432/mermerd_test"
-schema: "public"
+schema: 
+  - "public"
 
 # Define what tables should be used
 #useAllTables: true

--- a/exampleRunConfig.yaml
+++ b/exampleRunConfig.yaml
@@ -2,6 +2,7 @@
 connectionString: "postgresql://user:password@localhost:5432/mermerd_test"
 schema: 
   - "public"
+  - "other_db"
 
 # Define what tables should be used
 #useAllTables: true

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ package main
 /// - TableNameResponse model?
 /// - Aufteilung
 /// - config abwärtskompatibel?
+/// - auf schema einschränken bei der abfrage
 
 import (
 	"fmt"

--- a/main.go
+++ b/main.go
@@ -1,15 +1,6 @@
 package main
 
-/// TODO:  test
-/// - tests
-/// - TableNameResponse model?
-/// - Aufteilung
-/// - config abwärtskompatibel?
-/// - auf schema einschränken bei der abfrage
-
 import (
-	"fmt"
-
 	"github.com/spf13/viper"
 
 	"github.com/KarnerTh/mermerd/cmd"
@@ -22,10 +13,8 @@ var (
 )
 
 func main() {
-  test := "abc"
 	viper.Set("version", version)
 	viper.Set("commit", commit)
-  fmt.Print(test)
 
 	cmd.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,14 @@
 package main
 
+/// TODO:  test
+/// - tests
+/// - TableNameResponse model?
+/// - Aufteilung
+/// - config abwärtskompatibel?
+
 import (
+	"fmt"
+
 	"github.com/spf13/viper"
 
 	"github.com/KarnerTh/mermerd/cmd"
@@ -13,8 +21,10 @@ var (
 )
 
 func main() {
+  test := "abc"
 	viper.Set("version", version)
 	viper.Set("commit", commit)
+  fmt.Print(test)
 
 	cmd.Execute()
 }

--- a/mocks/Analyzer.go
+++ b/mocks/Analyzer.go
@@ -36,11 +36,11 @@ func (_m *Analyzer) Analyze() (*database.Result, error) {
 }
 
 // GetColumnsAndConstraints provides a mock function with given fields: db, selectedTables
-func (_m *Analyzer) GetColumnsAndConstraints(db database.Connector, selectedTables []database.TableNameResult) ([]database.TableResult, error) {
+func (_m *Analyzer) GetColumnsAndConstraints(db database.Connector, selectedTables []database.TableDetail) ([]database.TableResult, error) {
 	ret := _m.Called(db, selectedTables)
 
 	var r0 []database.TableResult
-	if rf, ok := ret.Get(0).(func(database.Connector, []database.TableNameResult) []database.TableResult); ok {
+	if rf, ok := ret.Get(0).(func(database.Connector, []database.TableDetail) []database.TableResult); ok {
 		r0 = rf(db, selectedTables)
 	} else {
 		if ret.Get(0) != nil {
@@ -49,7 +49,7 @@ func (_m *Analyzer) GetColumnsAndConstraints(db database.Connector, selectedTabl
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(database.Connector, []database.TableNameResult) error); ok {
+	if rf, ok := ret.Get(1).(func(database.Connector, []database.TableDetail) error); ok {
 		r1 = rf(db, selectedTables)
 	} else {
 		r1 = ret.Error(1)
@@ -103,15 +103,15 @@ func (_m *Analyzer) GetSchemas(db database.Connector) ([]string, error) {
 }
 
 // GetTables provides a mock function with given fields: db, selectedSchemas
-func (_m *Analyzer) GetTables(db database.Connector, selectedSchemas []string) ([]database.TableNameResult, error) {
+func (_m *Analyzer) GetTables(db database.Connector, selectedSchemas []string) ([]database.TableDetail, error) {
 	ret := _m.Called(db, selectedSchemas)
 
-	var r0 []database.TableNameResult
-	if rf, ok := ret.Get(0).(func(database.Connector, []string) []database.TableNameResult); ok {
+	var r0 []database.TableDetail
+	if rf, ok := ret.Get(0).(func(database.Connector, []string) []database.TableDetail); ok {
 		r0 = rf(db, selectedSchemas)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.TableNameResult)
+			r0 = ret.Get(0).([]database.TableDetail)
 		}
 	}
 

--- a/mocks/Analyzer.go
+++ b/mocks/Analyzer.go
@@ -36,11 +36,11 @@ func (_m *Analyzer) Analyze() (*database.Result, error) {
 }
 
 // GetColumnsAndConstraints provides a mock function with given fields: db, selectedTables
-func (_m *Analyzer) GetColumnsAndConstraints(db database.Connector, selectedTables []string) ([]database.TableResult, error) {
+func (_m *Analyzer) GetColumnsAndConstraints(db database.Connector, selectedTables []database.TableNameResult) ([]database.TableResult, error) {
 	ret := _m.Called(db, selectedTables)
 
 	var r0 []database.TableResult
-	if rf, ok := ret.Get(0).(func(database.Connector, []string) []database.TableResult); ok {
+	if rf, ok := ret.Get(0).(func(database.Connector, []database.TableNameResult) []database.TableResult); ok {
 		r0 = rf(db, selectedTables)
 	} else {
 		if ret.Get(0) != nil {
@@ -49,7 +49,7 @@ func (_m *Analyzer) GetColumnsAndConstraints(db database.Connector, selectedTabl
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(database.Connector, []string) error); ok {
+	if rf, ok := ret.Get(1).(func(database.Connector, []database.TableNameResult) error); ok {
 		r1 = rf(db, selectedTables)
 	} else {
 		r1 = ret.Error(1)
@@ -79,15 +79,17 @@ func (_m *Analyzer) GetConnectionString() (string, error) {
 	return r0, r1
 }
 
-// GetSchema provides a mock function with given fields: db
-func (_m *Analyzer) GetSchema(db database.Connector) (string, error) {
+// GetSchemas provides a mock function with given fields: db
+func (_m *Analyzer) GetSchemas(db database.Connector) ([]string, error) {
 	ret := _m.Called(db)
 
-	var r0 string
-	if rf, ok := ret.Get(0).(func(database.Connector) string); ok {
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(database.Connector) []string); ok {
 		r0 = rf(db)
 	} else {
-		r0 = ret.Get(0).(string)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
 	}
 
 	var r1 error
@@ -100,22 +102,22 @@ func (_m *Analyzer) GetSchema(db database.Connector) (string, error) {
 	return r0, r1
 }
 
-// GetTables provides a mock function with given fields: db, selectedSchema
-func (_m *Analyzer) GetTables(db database.Connector, selectedSchema string) ([]string, error) {
-	ret := _m.Called(db, selectedSchema)
+// GetTables provides a mock function with given fields: db, selectedSchemas
+func (_m *Analyzer) GetTables(db database.Connector, selectedSchemas []string) ([]database.TableNameResult, error) {
+	ret := _m.Called(db, selectedSchemas)
 
-	var r0 []string
-	if rf, ok := ret.Get(0).(func(database.Connector, string) []string); ok {
-		r0 = rf(db, selectedSchema)
+	var r0 []database.TableNameResult
+	if rf, ok := ret.Get(0).(func(database.Connector, []string) []database.TableNameResult); ok {
+		r0 = rf(db, selectedSchemas)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]string)
+			r0 = ret.Get(0).([]database.TableNameResult)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(database.Connector, string) error); ok {
-		r1 = rf(db, selectedSchema)
+	if rf, ok := ret.Get(1).(func(database.Connector, []string) error); ok {
+		r1 = rf(db, selectedSchemas)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/mocks/Connector.go
+++ b/mocks/Connector.go
@@ -32,11 +32,11 @@ func (_m *Connector) Connect() error {
 }
 
 // GetColumns provides a mock function with given fields: tableName
-func (_m *Connector) GetColumns(tableName database.TableNameResult) ([]database.ColumnResult, error) {
+func (_m *Connector) GetColumns(tableName database.TableDetail) ([]database.ColumnResult, error) {
 	ret := _m.Called(tableName)
 
 	var r0 []database.ColumnResult
-	if rf, ok := ret.Get(0).(func(database.TableNameResult) []database.ColumnResult); ok {
+	if rf, ok := ret.Get(0).(func(database.TableDetail) []database.ColumnResult); ok {
 		r0 = rf(tableName)
 	} else {
 		if ret.Get(0) != nil {
@@ -45,7 +45,7 @@ func (_m *Connector) GetColumns(tableName database.TableNameResult) ([]database.
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(database.TableNameResult) error); ok {
+	if rf, ok := ret.Get(1).(func(database.TableDetail) error); ok {
 		r1 = rf(tableName)
 	} else {
 		r1 = ret.Error(1)
@@ -55,11 +55,11 @@ func (_m *Connector) GetColumns(tableName database.TableNameResult) ([]database.
 }
 
 // GetConstraints provides a mock function with given fields: tableName
-func (_m *Connector) GetConstraints(tableName database.TableNameResult) ([]database.ConstraintResult, error) {
+func (_m *Connector) GetConstraints(tableName database.TableDetail) ([]database.ConstraintResult, error) {
 	ret := _m.Called(tableName)
 
 	var r0 []database.ConstraintResult
-	if rf, ok := ret.Get(0).(func(database.TableNameResult) []database.ConstraintResult); ok {
+	if rf, ok := ret.Get(0).(func(database.TableDetail) []database.ConstraintResult); ok {
 		r0 = rf(tableName)
 	} else {
 		if ret.Get(0) != nil {
@@ -68,7 +68,7 @@ func (_m *Connector) GetConstraints(tableName database.TableNameResult) ([]datab
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(database.TableNameResult) error); ok {
+	if rf, ok := ret.Get(1).(func(database.TableDetail) error); ok {
 		r1 = rf(tableName)
 	} else {
 		r1 = ret.Error(1)
@@ -115,15 +115,15 @@ func (_m *Connector) GetSchemas() ([]string, error) {
 }
 
 // GetTables provides a mock function with given fields: schemaNames
-func (_m *Connector) GetTables(schemaNames []string) ([]database.TableNameResult, error) {
+func (_m *Connector) GetTables(schemaNames []string) ([]database.TableDetail, error) {
 	ret := _m.Called(schemaNames)
 
-	var r0 []database.TableNameResult
-	if rf, ok := ret.Get(0).(func([]string) []database.TableNameResult); ok {
+	var r0 []database.TableDetail
+	if rf, ok := ret.Get(0).(func([]string) []database.TableDetail); ok {
 		r0 = rf(schemaNames)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]database.TableNameResult)
+			r0 = ret.Get(0).([]database.TableDetail)
 		}
 	}
 

--- a/mocks/Connector.go
+++ b/mocks/Connector.go
@@ -32,11 +32,11 @@ func (_m *Connector) Connect() error {
 }
 
 // GetColumns provides a mock function with given fields: tableName
-func (_m *Connector) GetColumns(tableName string) ([]database.ColumnResult, error) {
+func (_m *Connector) GetColumns(tableName database.TableNameResult) ([]database.ColumnResult, error) {
 	ret := _m.Called(tableName)
 
 	var r0 []database.ColumnResult
-	if rf, ok := ret.Get(0).(func(string) []database.ColumnResult); ok {
+	if rf, ok := ret.Get(0).(func(database.TableNameResult) []database.ColumnResult); ok {
 		r0 = rf(tableName)
 	} else {
 		if ret.Get(0) != nil {
@@ -45,7 +45,7 @@ func (_m *Connector) GetColumns(tableName string) ([]database.ColumnResult, erro
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
+	if rf, ok := ret.Get(1).(func(database.TableNameResult) error); ok {
 		r1 = rf(tableName)
 	} else {
 		r1 = ret.Error(1)
@@ -55,11 +55,11 @@ func (_m *Connector) GetColumns(tableName string) ([]database.ColumnResult, erro
 }
 
 // GetConstraints provides a mock function with given fields: tableName
-func (_m *Connector) GetConstraints(tableName string) ([]database.ConstraintResult, error) {
+func (_m *Connector) GetConstraints(tableName database.TableNameResult) ([]database.ConstraintResult, error) {
 	ret := _m.Called(tableName)
 
 	var r0 []database.ConstraintResult
-	if rf, ok := ret.Get(0).(func(string) []database.ConstraintResult); ok {
+	if rf, ok := ret.Get(0).(func(database.TableNameResult) []database.ConstraintResult); ok {
 		r0 = rf(tableName)
 	} else {
 		if ret.Get(0) != nil {
@@ -68,7 +68,7 @@ func (_m *Connector) GetConstraints(tableName string) ([]database.ConstraintResu
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
+	if rf, ok := ret.Get(1).(func(database.TableNameResult) error); ok {
 		r1 = rf(tableName)
 	} else {
 		r1 = ret.Error(1)
@@ -114,22 +114,22 @@ func (_m *Connector) GetSchemas() ([]string, error) {
 	return r0, r1
 }
 
-// GetTables provides a mock function with given fields: schemaName
-func (_m *Connector) GetTables(schemaName string) ([]string, error) {
-	ret := _m.Called(schemaName)
+// GetTables provides a mock function with given fields: schemaNames
+func (_m *Connector) GetTables(schemaNames []string) ([]database.TableNameResult, error) {
+	ret := _m.Called(schemaNames)
 
-	var r0 []string
-	if rf, ok := ret.Get(0).(func(string) []string); ok {
-		r0 = rf(schemaName)
+	var r0 []database.TableNameResult
+	if rf, ok := ret.Get(0).(func([]string) []database.TableNameResult); ok {
+		r0 = rf(schemaNames)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]string)
+			r0 = ret.Get(0).([]database.TableNameResult)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(schemaName)
+	if rf, ok := ret.Get(1).(func([]string) error); ok {
+		r1 = rf(schemaNames)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/mocks/MermerdConfig.go
+++ b/mocks/MermerdConfig.go
@@ -109,15 +109,17 @@ func (_m *MermerdConfig) OutputFileName() string {
 	return r0
 }
 
-// Schema provides a mock function with given fields:
-func (_m *MermerdConfig) Schema() string {
+// Schemas provides a mock function with given fields:
+func (_m *MermerdConfig) Schemas() []string {
 	ret := _m.Called()
 
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
+	var r0 []string
+	if rf, ok := ret.Get(0).(func() []string); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Get(0).(string)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
 	}
 
 	return r0

--- a/mocks/MermerdConfig.go
+++ b/mocks/MermerdConfig.go
@@ -169,6 +169,20 @@ func (_m *MermerdConfig) ShowEnumValues() bool {
 	return r0
 }
 
+// UseAllSchemas provides a mock function with given fields:
+func (_m *MermerdConfig) UseAllSchemas() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // UseAllTables provides a mock function with given fields:
 func (_m *MermerdConfig) UseAllTables() bool {
 	ret := _m.Called()

--- a/mocks/Questioner.go
+++ b/mocks/Questioner.go
@@ -31,14 +31,16 @@ func (_m *Questioner) AskConnectionQuestion(suggestions []string) (string, error
 }
 
 // AskSchemaQuestion provides a mock function with given fields: schemas
-func (_m *Questioner) AskSchemaQuestion(schemas []string) (string, error) {
+func (_m *Questioner) AskSchemaQuestion(schemas []string) ([]string, error) {
 	ret := _m.Called(schemas)
 
-	var r0 string
-	if rf, ok := ret.Get(0).(func([]string) string); ok {
+	var r0 []string
+	if rf, ok := ret.Get(0).(func([]string) []string); ok {
 		r0 = rf(schemas)
 	} else {
-		r0 = ret.Get(0).(string)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
 	}
 
 	var r1 error

--- a/readme.md
+++ b/readme.md
@@ -117,7 +117,9 @@ shown below) and start mermerd via `mermerd --runConfig yourRunConfig.yaml`
 ```yaml
 # Connection properties
 connectionString: "postgresql://user:password@localhost:5432/yourDb"
-schema: "public"
+schema: 
+  - "public"
+  - "other_db"
 
 # Define what tables should be used
 useAllTables: true

--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,7 @@ via `mermerd -h`
       --selectedTables strings        tables to include
       --showAllConstraints            show all constraints, even though the table of the resulting constraint was not selected
       --showEnumValues                show enum values in description column
+      --useAllSchemas                 use all available schemas
       --useAllTables                  use all available tables
 ```
 
@@ -117,6 +118,10 @@ shown below) and start mermerd via `mermerd --runConfig yourRunConfig.yaml`
 ```yaml
 # Connection properties
 connectionString: "postgresql://user:password@localhost:5432/yourDb"
+
+# Define what schemas should be used
+useAllSchemas: true
+# or
 schema: 
   - "public"
   - "other_db"

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -11,6 +11,7 @@ services:
     volumes:
       - ./db-table-setup.sql:/docker-entrypoint-initdb.d/1.sql
       - ./postgres/postgres-enum-setup.sql:/docker-entrypoint-initdb.d/2.sql
+      - ./postgres/postgres-multiple-databases.sql:/docker-entrypoint-initdb.d/3.sql
   mermerd-mysql-test-db:
     image: mysql:8.0
     command: --default-authentication-plugin=mysql_native_password
@@ -36,6 +37,7 @@ services:
       - ./db-table-setup.sql:/usr/src/app/db-table-setup.sql
       - ./mssql/mssql-setup.sql:/usr/src/app/mssql-setup.sql
       - ./mssql/mssql-enum-setup.sql:/usr/src/app/mssql-enum-setup.sql
+      - ./mssql/mssql-multiple-databases.sql:/usr/src/app/mssql-multiple-databases.sql
       - ./mssql/entrypoint.sh:/usr/src/app/entrypoint.sh
     working_dir: /usr/src/app
     command: sh -c './entrypoint.sh & /opt/mssql/bin/sqlservr;'

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -24,6 +24,7 @@ services:
     volumes:
       - ./db-table-setup.sql:/docker-entrypoint-initdb.d/1.sql
       - ./mysql/mysql-enum-setup.sql:/docker-entrypoint-initdb.d/2.sql
+      - ./mysql/mysql-multiple-databases.sql:/docker-entrypoint-initdb.d/3.sql
   mermerd-mssql-test-db:
     image: mcr.microsoft.com/mssql/server:2019-latest
     environment:

--- a/test/mssql/entrypoint.sh
+++ b/test/mssql/entrypoint.sh
@@ -12,5 +12,6 @@ echo importing data...
 /opt/mssql-tools/bin/sqlcmd -S 0.0.0.0 -U sa -P $password -i ./mssql-setup.sql
 /opt/mssql-tools/bin/sqlcmd -S 0.0.0.0 -U sa -P $password -d mermerd_test -i ./db-table-setup.sql
 /opt/mssql-tools/bin/sqlcmd -S 0.0.0.0 -U sa -P $password -d mermerd_test -i ./mssql-enum-setup.sql
+/opt/mssql-tools/bin/sqlcmd -S 0.0.0.0 -U sa -P $password -d mermerd_test -i ./mssql-multiple-databases.sql
 
 echo importing done

--- a/test/mssql/mssql-multiple-databases.sql
+++ b/test/mssql/mssql-multiple-databases.sql
@@ -1,0 +1,26 @@
+-- Test case for https://github.com/KarnerTh/mermerd/issues/23
+create table dbo.test_3_a
+(
+    id    int          not null primary key,
+    title varchar(255) not null
+);
+
+GO
+
+create schema other_db;
+
+GO
+
+create table other_db.test_3_b
+(
+    id    int          not null primary key,
+    aid int,
+    foreign key (aid) references dbo.test_3_a (id)
+);
+
+create table other_db.test_3_c
+(
+    id    int          not null primary key,
+    title varchar(255) not null
+);
+

--- a/test/mysql/mysql-multiple-databases.sql
+++ b/test/mysql/mysql-multiple-databases.sql
@@ -1,0 +1,23 @@
+-- Test case for https://github.com/KarnerTh/mermerd/issues/23
+create table test_3_a
+(
+    id    int          not null primary key,
+    title varchar(255) not null
+);
+
+create database other_db;
+use other_db;
+
+create table test_3_b
+(
+    id    int          not null primary key,
+    aid int,
+    foreign key (aid) references mermerd_test.test_3_a (id)
+);
+
+create table test_3_c
+(
+    id    int          not null primary key,
+    title varchar(255) not null
+);
+

--- a/test/postgres/postgres-multiple-databases.sql
+++ b/test/postgres/postgres-multiple-databases.sql
@@ -1,0 +1,22 @@
+-- Test case for https://github.com/KarnerTh/mermerd/issues/23
+create table test_3_a
+(
+    id    int          not null primary key,
+    title varchar(255) not null
+);
+
+create schema other_db;
+
+create table other_db.test_3_b
+(
+    id    int          not null primary key,
+    aid   int,
+    foreign key (aid) references public.test_3_a (id)
+);
+
+create table other_db.test_3_c
+(
+    id    int          not null primary key,
+    title varchar(255) not null
+);
+

--- a/util/map_util.go
+++ b/util/map_util.go
@@ -1,0 +1,10 @@
+package util
+
+func Map2[T, U any](data []T, f func(T) U) []U {
+	res := make([]U, 0, len(data))
+	for _, e := range data {
+		res = append(res, f(e))
+	}
+
+	return res
+}


### PR DESCRIPTION
Fixes #23 

Add support for multiple schemas

* multiselection via cli
* list of schemas in (run-)config
* a `--useAllSchemas` flag

The existing `schema` config now accepts a list of schemas