### PR TITLE
Support column comments

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,12 +69,12 @@ func init() {
 	rootCmd.Flags().Bool(config.DebugKey, false, "show debug logs")
 	rootCmd.Flags().Bool(config.OmitConstraintLabelsKey, false, "omit the constraint labels")
 	rootCmd.Flags().Bool(config.OmitAttributeKeysKey, false, "omit the attribute keys (PK, FK)")
-	rootCmd.Flags().Bool(config.ShowEnumValuesKey, false, "show enum values in description column")
 	rootCmd.Flags().Bool(config.ShowSchemaPrefix, false, "show schema prefix in table name")
 	rootCmd.Flags().BoolP(config.EncloseWithMermaidBackticksKey, "e", false, "enclose output with mermaid backticks (needed for e.g. in markdown viewer)")
 	rootCmd.Flags().StringP(config.ConnectionStringKey, "c", "", "connection string that should be used")
 	rootCmd.Flags().StringP(config.SchemaKey, "s", "", "schema that should be used")
 	rootCmd.Flags().StringP(config.OutputFileNameKey, "o", "result.mmd", "output file name")
+	rootCmd.Flags().String(config.ShowDescriptionsKey, "", "show 'enumValues' or 'columnComments' in description column")
 	rootCmd.Flags().String(config.SchemaPrefixSeparator, ".", "the separator that should be used between schema and table name")
 	rootCmd.Flags().StringSlice(config.SelectedTablesKey, []string{""}, "tables to include")
 
@@ -89,7 +89,7 @@ func init() {
 	bindFlagToViper(config.SchemaKey)
 	bindFlagToViper(config.OutputFileNameKey)
 	bindFlagToViper(config.SelectedTablesKey)
-	bindFlagToViper(config.ShowEnumValuesKey)
+	bindFlagToViper(config.ShowDescriptionsKey)
 	bindFlagToViper(config.ShowSchemaPrefix)
 	bindFlagToViper(config.SchemaPrefixSeparator)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,7 +75,7 @@ func init() {
 	rootCmd.Flags().StringP(config.SchemaKey, "s", "", "schema that should be used")
 	rootCmd.Flags().StringP(config.OutputFileNameKey, "o", "result.mmd", "output file name")
 	rootCmd.Flags().String(config.SchemaPrefixSeparator, ".", "the separator that should be used between schema and table name")
-	rootCmd.Flags().StringSlice(config.ShowDescriptionsKey, []string{""}, "show 'enumValues' and/or 'columnComments' in description column")
+	rootCmd.Flags().StringSlice(config.ShowDescriptionsKey, []string{""}, "show 'enumValues' and/or 'columnComments' in the description column")
 	rootCmd.Flags().StringSlice(config.SelectedTablesKey, []string{""}, "tables to include")
 
 	bindFlagToViper(config.ShowAllConstraintsKey)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,8 +74,8 @@ func init() {
 	rootCmd.Flags().StringP(config.ConnectionStringKey, "c", "", "connection string that should be used")
 	rootCmd.Flags().StringP(config.SchemaKey, "s", "", "schema that should be used")
 	rootCmd.Flags().StringP(config.OutputFileNameKey, "o", "result.mmd", "output file name")
-	rootCmd.Flags().String(config.ShowDescriptionsKey, "", "show 'enumValues' or 'columnComments' in description column")
 	rootCmd.Flags().String(config.SchemaPrefixSeparator, ".", "the separator that should be used between schema and table name")
+	rootCmd.Flags().StringSlice(config.ShowDescriptionsKey, []string{""}, "show 'enumValues' and/or 'columnComments' in description column")
 	rootCmd.Flags().StringSlice(config.SelectedTablesKey, []string{""}, "tables to include")
 
 	bindFlagToViper(config.ShowAllConstraintsKey)

--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,7 @@ type MermerdConfig interface {
 	Debug() bool
 	OmitConstraintLabels() bool
 	OmitAttributeKeys() bool
-	ShowDescriptions() string
+	ShowDescriptions() []string
 	UseAllSchemas() bool
 	ShowSchemaPrefix() bool
 	SchemaPrefixSeparator() string
@@ -88,8 +88,8 @@ func (c config) OmitAttributeKeys() bool {
 	return viper.GetBool(OmitAttributeKeysKey)
 }
 
-func (c config) ShowDescriptions() string {
-	return viper.GetString(ShowDescriptionsKey)
+func (c config) ShowDescriptions() []string {
+	return viper.GetStringSlice(ShowDescriptionsKey)
 }
 
 func (c config) UseAllSchemas() bool {

--- a/config/config.go
+++ b/config/config.go
@@ -14,7 +14,7 @@ const (
 	DebugKey                       = "debug"
 	OmitConstraintLabelsKey        = "omitConstraintLabels"
 	OmitAttributeKeysKey           = "omitAttributeKeys"
-	ShowEnumValuesKey              = "showEnumValues"
+	ShowDescriptionsKey            = "showDescriptions"
 	UseAllSchemasKey               = "useAllSchemas"
 	ShowSchemaPrefix               = "showSchemaPrefix"
 	SchemaPrefixSeparator          = "schemaPrefixSeparator"
@@ -34,7 +34,7 @@ type MermerdConfig interface {
 	Debug() bool
 	OmitConstraintLabels() bool
 	OmitAttributeKeys() bool
-	ShowEnumValues() bool
+	ShowDescriptions() string
 	UseAllSchemas() bool
 	ShowSchemaPrefix() bool
 	SchemaPrefixSeparator() string
@@ -88,8 +88,8 @@ func (c config) OmitAttributeKeys() bool {
 	return viper.GetBool(OmitAttributeKeysKey)
 }
 
-func (c config) ShowEnumValues() bool {
-	return viper.GetBool(ShowEnumValuesKey)
+func (c config) ShowDescriptions() string {
+	return viper.GetString(ShowDescriptionsKey)
 }
 
 func (c config) UseAllSchemas() bool {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,7 +28,9 @@ encloseWithMermaidBackticks: false
 debug: true
 omitConstraintLabels: true
 omitAttributeKeys: true
-showDescriptions: "enumValues"
+showDescriptions:
+  - enumValues
+  - columnComments
 useAllSchemas: true
 showSchemaPrefix: true
 schemaPrefixSeparator: "_"
@@ -56,7 +58,7 @@ connectionStringSuggestions:
 	assert.True(t, config.Debug())
 	assert.True(t, config.OmitConstraintLabels())
 	assert.True(t, config.OmitAttributeKeys())
-	assert.Equal(t, "enumValues", config.ShowDescriptions())
+	assert.ElementsMatch(t, []string{"enumValues", "columnComments"}, config.ShowDescriptions())
 	assert.True(t, config.UseAllSchemas())
 	assert.True(t, config.ShowSchemaPrefix())
 	assert.Equal(t, "_", config.SchemaPrefixSeparator())

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,7 +28,7 @@ encloseWithMermaidBackticks: false
 debug: true
 omitConstraintLabels: true
 omitAttributeKeys: true
-showEnumValues: true
+showDescriptions: "enumValues"
 useAllSchemas: true
 showSchemaPrefix: true
 schemaPrefixSeparator: "_"
@@ -56,7 +56,7 @@ connectionStringSuggestions:
 	assert.True(t, config.Debug())
 	assert.True(t, config.OmitConstraintLabels())
 	assert.True(t, config.OmitAttributeKeys())
-	assert.True(t, config.ShowEnumValues())
+	assert.Equal(t, "enumValues", config.ShowDescriptions())
 	assert.True(t, config.UseAllSchemas())
 	assert.True(t, config.ShowSchemaPrefix())
 	assert.Equal(t, "_", config.SchemaPrefixSeparator())

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -99,7 +99,8 @@ func (c *mySqlConnector) GetColumns(tableName TableDetail) ([]ColumnResult, erro
 				where cu.column_name = c.column_name
 				  and cu.table_name = c.table_name
 				  and tc.constraint_type = 'FOREIGN KEY') as is_foreign,
-        case when c.data_type = 'enum' then REPLACE(REPLACE(REPLACE(REPLACE(c.column_type, 'enum', ''), '\'', ''), '(', ''), ')', '') else '' end as enum_values
+        case when c.data_type = 'enum' then REPLACE(REPLACE(REPLACE(REPLACE(c.column_type, 'enum', ''), '\'', ''), '(', ''), ')', '') else '' end as enum_values,
+		c.column_comment as comment
 		from information_schema.columns c
 		where c.table_name = ? and c.TABLE_SCHEMA = ?
 		order by c.ordinal_position;
@@ -111,7 +112,7 @@ func (c *mySqlConnector) GetColumns(tableName TableDetail) ([]ColumnResult, erro
 	var columns []ColumnResult
 	for rows.Next() {
 		var column ColumnResult
-		if err = rows.Scan(&column.Name, &column.DataType, &column.IsPrimary, &column.IsForeign, &column.EnumValues); err != nil {
+		if err = rows.Scan(&column.Name, &column.DataType, &column.IsPrimary, &column.IsForeign, &column.EnumValues, &column.Comment); err != nil {
 			return nil, err
 		}
 

--- a/database/result.go
+++ b/database/result.go
@@ -21,6 +21,7 @@ type ColumnResult struct {
 	IsPrimary  bool
 	IsForeign  bool
 	EnumValues string
+	Comment    string
 }
 
 type ConstraintResultList []ConstraintResult

--- a/diagram/diagram_data.go
+++ b/diagram/diagram_data.go
@@ -29,7 +29,7 @@ type ErdTableData struct {
 type ErdColumnData struct {
 	Name         string
 	DataType     string
-	EnumValues   string
+	Description  string
 	AttributeKey ErdAttributeKey
 }
 

--- a/diagram/diagram_util.go
+++ b/diagram/diagram_util.go
@@ -2,6 +2,8 @@ package diagram
 
 import (
 	"fmt"
+	"github.com/sirupsen/logrus"
+	"strings"
 
 	"github.com/KarnerTh/mermerd/config"
 	"github.com/KarnerTh/mermerd/database"
@@ -43,22 +45,29 @@ func getColumnData(config config.MermerdConfig, column database.ColumnResult) Er
 		attributeKey = none
 	}
 
-	var description string
-	var showDescriptions = config.ShowDescriptions()
-	if showDescriptions == "enumValues" {
-		description = column.EnumValues
-	} else if showDescriptions == "columnComments" {
-		description = column.Comment
-	} else {
-
-	}
-
 	return ErdColumnData{
 		Name:         column.Name,
 		DataType:     column.DataType,
-		Description:  description,
+		Description:  getDescription(config.ShowDescriptions(), column),
 		AttributeKey: attributeKey,
 	}
+}
+
+func getDescription(options []string, column database.ColumnResult) string {
+	var description []string
+	for _, option := range options {
+		switch option {
+		case "enumValues":
+			if column.EnumValues != "" {
+				description = append(description, "<"+column.EnumValues+">")
+			}
+		case "columnComments":
+			description = append(description, column.Comment)
+		default:
+			logrus.Errorf("Could not parse option %q", option)
+		}
+	}
+	return strings.TrimSpace(strings.Join(description, " "))
 }
 
 func shouldSkipConstraint(config config.MermerdConfig, tables []ErdTableData, constraint database.ConstraintResult) bool {

--- a/diagram/diagram_util.go
+++ b/diagram/diagram_util.go
@@ -43,15 +43,20 @@ func getColumnData(config config.MermerdConfig, column database.ColumnResult) Er
 		attributeKey = none
 	}
 
-	var enumValues string
-	if config.ShowEnumValues() {
-		enumValues = column.EnumValues
+	var description string
+	var showDescriptions = config.ShowDescriptions()
+	if showDescriptions == "enumValues" {
+		description = column.EnumValues
+	} else if showDescriptions == "columnComments" {
+		description = column.Comment
+	} else {
+
 	}
 
 	return ErdColumnData{
 		Name:         column.Name,
 		DataType:     column.DataType,
-		EnumValues:   enumValues,
+		Description:  description,
 		AttributeKey: attributeKey,
 	}
 }

--- a/diagram/diagram_util_test.go
+++ b/diagram/diagram_util_test.go
@@ -136,11 +136,11 @@ func TestGetColumnData(t *testing.T) {
 		Comment:    comment,
 	}
 
-	t.Run("Get all fields with enum values", func(t *testing.T) {
+	t.Run("Get all fields", func(t *testing.T) {
 		// Arrange
 		configMock := mocks.MermerdConfig{}
 		configMock.On("OmitAttributeKeys").Return(false).Once()
-		configMock.On("ShowDescriptions").Return("enumValues").Once()
+		configMock.On("ShowDescriptions").Return([]string{"enumValues", "columnComments"}).Once()
 
 		// Act
 		result := getColumnData(&configMock, column)
@@ -148,15 +148,31 @@ func TestGetColumnData(t *testing.T) {
 		// Assert
 		configMock.AssertExpectations(t)
 		assert.Equal(t, columnName, result.Name)
-		assert.Equal(t, enumValues, result.Description)
+		assert.Equal(t, "<"+enumValues+"> "+comment, result.Description)
 		assert.Equal(t, primaryKey, result.AttributeKey)
 	})
 
-	t.Run("Get all fields with comments", func(t *testing.T) {
+	t.Run("Get all fields with enum values", func(t *testing.T) {
 		// Arrange
 		configMock := mocks.MermerdConfig{}
 		configMock.On("OmitAttributeKeys").Return(false).Once()
-		configMock.On("ShowDescriptions").Return("columnComments").Once()
+		configMock.On("ShowDescriptions").Return([]string{"enumValues"}).Once()
+
+		// Act
+		result := getColumnData(&configMock, column)
+
+		// Assert
+		configMock.AssertExpectations(t)
+		assert.Equal(t, columnName, result.Name)
+		assert.Equal(t, "<"+enumValues+">", result.Description)
+		assert.Equal(t, primaryKey, result.AttributeKey)
+	})
+
+	t.Run("Get all fields with column comments", func(t *testing.T) {
+		// Arrange
+		configMock := mocks.MermerdConfig{}
+		configMock.On("OmitAttributeKeys").Return(false).Once()
+		configMock.On("ShowDescriptions").Return([]string{"columnComments"}).Once()
 
 		// Act
 		result := getColumnData(&configMock, column)
@@ -172,7 +188,7 @@ func TestGetColumnData(t *testing.T) {
 		// Arrange
 		configMock := mocks.MermerdConfig{}
 		configMock.On("OmitAttributeKeys").Return(false).Once()
-		configMock.On("ShowDescriptions").Return("").Once()
+		configMock.On("ShowDescriptions").Return([]string{""}).Once()
 
 		// Act
 		result := getColumnData(&configMock, column)
@@ -188,7 +204,7 @@ func TestGetColumnData(t *testing.T) {
 		// Arrange
 		configMock := mocks.MermerdConfig{}
 		configMock.On("OmitAttributeKeys").Return(true).Once()
-		configMock.On("ShowDescriptions").Return("enumValues").Once()
+		configMock.On("ShowDescriptions").Return([]string{"enumValues", "columnComments"}).Once()
 
 		// Act
 		result := getColumnData(&configMock, column)
@@ -196,7 +212,7 @@ func TestGetColumnData(t *testing.T) {
 		// Assert
 		configMock.AssertExpectations(t)
 		assert.Equal(t, columnName, result.Name)
-		assert.Equal(t, enumValues, result.Description)
+		assert.Equal(t, "<"+enumValues+"> "+comment, result.Description)
 		assert.Equal(t, none, result.AttributeKey)
 	})
 
@@ -204,7 +220,7 @@ func TestGetColumnData(t *testing.T) {
 		// Arrange
 		configMock := mocks.MermerdConfig{}
 		configMock.On("OmitAttributeKeys").Return(true).Once()
-		configMock.On("ShowDescriptions").Return("").Once()
+		configMock.On("ShowDescriptions").Return([]string{""}).Once()
 
 		// Act
 		result := getColumnData(&configMock, column)

--- a/diagram/diagram_util_test.go
+++ b/diagram/diagram_util_test.go
@@ -128,17 +128,19 @@ func TestTableNameInSlice(t *testing.T) {
 func TestGetColumnData(t *testing.T) {
 	columnName := "testColumn"
 	enumValues := "a,b"
+	comment := "comment"
 	column := database.ColumnResult{
 		Name:       columnName,
 		IsPrimary:  true,
 		EnumValues: enumValues,
+		Comment:    comment,
 	}
 
-	t.Run("Get all fields", func(t *testing.T) {
+	t.Run("Get all fields with enum values", func(t *testing.T) {
 		// Arrange
 		configMock := mocks.MermerdConfig{}
 		configMock.On("OmitAttributeKeys").Return(false).Once()
-		configMock.On("ShowEnumValues").Return(true).Once()
+		configMock.On("ShowDescriptions").Return("enumValues").Once()
 
 		// Act
 		result := getColumnData(&configMock, column)
@@ -146,15 +148,15 @@ func TestGetColumnData(t *testing.T) {
 		// Assert
 		configMock.AssertExpectations(t)
 		assert.Equal(t, columnName, result.Name)
-		assert.Equal(t, enumValues, result.EnumValues)
+		assert.Equal(t, enumValues, result.Description)
 		assert.Equal(t, primaryKey, result.AttributeKey)
 	})
 
-	t.Run("Get all fields except enum values", func(t *testing.T) {
+	t.Run("Get all fields with comments", func(t *testing.T) {
 		// Arrange
 		configMock := mocks.MermerdConfig{}
 		configMock.On("OmitAttributeKeys").Return(false).Once()
-		configMock.On("ShowEnumValues").Return(false).Once()
+		configMock.On("ShowDescriptions").Return("columnComments").Once()
 
 		// Act
 		result := getColumnData(&configMock, column)
@@ -162,7 +164,23 @@ func TestGetColumnData(t *testing.T) {
 		// Assert
 		configMock.AssertExpectations(t)
 		assert.Equal(t, columnName, result.Name)
-		assert.Equal(t, "", result.EnumValues)
+		assert.Equal(t, comment, result.Description)
+		assert.Equal(t, primaryKey, result.AttributeKey)
+	})
+
+	t.Run("Get all fields except description", func(t *testing.T) {
+		// Arrange
+		configMock := mocks.MermerdConfig{}
+		configMock.On("OmitAttributeKeys").Return(false).Once()
+		configMock.On("ShowDescriptions").Return("").Once()
+
+		// Act
+		result := getColumnData(&configMock, column)
+
+		// Assert
+		configMock.AssertExpectations(t)
+		assert.Equal(t, columnName, result.Name)
+		assert.Equal(t, "", result.Description)
 		assert.Equal(t, primaryKey, result.AttributeKey)
 	})
 
@@ -170,7 +188,7 @@ func TestGetColumnData(t *testing.T) {
 		// Arrange
 		configMock := mocks.MermerdConfig{}
 		configMock.On("OmitAttributeKeys").Return(true).Once()
-		configMock.On("ShowEnumValues").Return(true).Once()
+		configMock.On("ShowDescriptions").Return("enumValues").Once()
 
 		// Act
 		result := getColumnData(&configMock, column)
@@ -178,7 +196,7 @@ func TestGetColumnData(t *testing.T) {
 		// Assert
 		configMock.AssertExpectations(t)
 		assert.Equal(t, columnName, result.Name)
-		assert.Equal(t, enumValues, result.EnumValues)
+		assert.Equal(t, enumValues, result.Description)
 		assert.Equal(t, none, result.AttributeKey)
 	})
 
@@ -186,7 +204,7 @@ func TestGetColumnData(t *testing.T) {
 		// Arrange
 		configMock := mocks.MermerdConfig{}
 		configMock.On("OmitAttributeKeys").Return(true).Once()
-		configMock.On("ShowEnumValues").Return(false).Once()
+		configMock.On("ShowDescriptions").Return("").Once()
 
 		// Act
 		result := getColumnData(&configMock, column)
@@ -194,7 +212,7 @@ func TestGetColumnData(t *testing.T) {
 		// Assert
 		configMock.AssertExpectations(t)
 		assert.Equal(t, columnName, result.Name)
-		assert.Equal(t, "", result.EnumValues)
+		assert.Equal(t, "", result.Description)
 		assert.Equal(t, none, result.AttributeKey)
 	})
 }

--- a/diagram/erd_template.gommd
+++ b/diagram/erd_template.gommd
@@ -3,7 +3,7 @@ erDiagram
 {{- range .Tables}}
     {{.Name}} {
     {{- range .Columns}}
-        {{.DataType}} {{.Name}} {{.AttributeKey}} {{- if .EnumValues}}"{{.EnumValues}}"{{end -}}
+        {{.DataType}} {{.Name}} {{.AttributeKey}} {{- if .Description}}"{{.Description}}"{{end -}}
     {{- end}}
     }
 {{end -}}

--- a/exampleRunConfig.yaml
+++ b/exampleRunConfig.yaml
@@ -20,6 +20,8 @@ encloseWithMermaidBackticks: false
 debug: false
 omitConstraintLabels: false
 omitAttributeKeys: false
-showDescriptions: "enumValues"
+showDescriptions:
+  - enumValues
+  - columnComments
 showSchemaPrefix: true
 schemaPrefixSeparator: "_"

--- a/exampleRunConfig.yaml
+++ b/exampleRunConfig.yaml
@@ -20,6 +20,6 @@ encloseWithMermaidBackticks: false
 debug: false
 omitConstraintLabels: false
 omitAttributeKeys: false
-showEnumValues: false
+showDescriptions: "enumValues"
 showSchemaPrefix: true
 schemaPrefixSeparator: "_"

--- a/mocks/MermerdConfig.go
+++ b/mocks/MermerdConfig.go
@@ -169,15 +169,15 @@ func (_m *MermerdConfig) ShowAllConstraints() bool {
 	return r0
 }
 
-// ShowEnumValues provides a mock function with given fields:
-func (_m *MermerdConfig) ShowEnumValues() bool {
+// ShowDescriptions provides a mock function with given fields:
+func (_m *MermerdConfig) ShowDescriptions() string {
 	ret := _m.Called()
 
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Get(0).(bool)
+		r0 = ret.Get(0).(string)
 	}
 
 	return r0

--- a/mocks/MermerdConfig.go
+++ b/mocks/MermerdConfig.go
@@ -170,14 +170,16 @@ func (_m *MermerdConfig) ShowAllConstraints() bool {
 }
 
 // ShowDescriptions provides a mock function with given fields:
-func (_m *MermerdConfig) ShowDescriptions() string {
+func (_m *MermerdConfig) ShowDescriptions() []string {
 	ret := _m.Called()
 
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
+	var r0 []string
+	if rf, ok := ret.Get(0).(func() []string); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Get(0).(string)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
 	}
 
 	return r0

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,7 @@ for your operating system. To be able to use it globally on your system, add the
 * Either generate plain mermaid syntax or enclose it with mermaid backticks to use directly in e.g. GitHub markdown
 * Show primary and foreign keys
 * Show enum values of enum column
+* Show column comments
 
 ## Why would I need it / Why should I care?
 
@@ -80,7 +81,7 @@ via `mermerd -h`
       --schemaPrefixSeparator string  the separator that should be used between schema and table name (default ".")
       --selectedTables strings        tables to include
       --showAllConstraints            show all constraints, even though the table of the resulting constraint was not selected
-      --showEnumValues                show enum values in description column
+      --showDescriptions string       show 'enumValues' or 'columnComments' in description column
       --showSchemaPrefix              show schema prefix in table name
       --useAllSchemas                 use all available schemas
       --useAllTables                  use all available tables
@@ -103,7 +104,7 @@ outputFileName: "my-db.mmd"
 debug: false
 omitConstraintLabels: false
 omitAttributeKeys: false
-showEnumValues: false
+showDescriptions: "enumValues"
 showSchemaPrefix: true
 schemaPrefixSeparator: "_"
 
@@ -144,7 +145,7 @@ outputFileName: "my-db.mmd"
 debug: true
 omitConstraintLabels: true
 omitAttributeKeys: true
-showEnumValues: true
+showDescriptions: "columnComments"
 showSchemaPrefix: true
 schemaPrefixSeparator: "_"
 ```

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ via `mermerd -h`
       --schemaPrefixSeparator string  the separator that should be used between schema and table name (default ".")
       --selectedTables strings        tables to include
       --showAllConstraints            show all constraints, even though the table of the resulting constraint was not selected
-      --showDescriptions strings      show 'enumValues' and/or 'columnComments' in description column
+      --showDescriptions strings      show 'enumValues' and/or 'columnComments' in the description column
       --showSchemaPrefix              show schema prefix in table name
       --useAllSchemas                 use all available schemas
       --useAllTables                  use all available tables

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ via `mermerd -h`
       --schemaPrefixSeparator string  the separator that should be used between schema and table name (default ".")
       --selectedTables strings        tables to include
       --showAllConstraints            show all constraints, even though the table of the resulting constraint was not selected
-      --showDescriptions string       show 'enumValues' or 'columnComments' in description column
+      --showDescriptions strings      show 'enumValues' and/or 'columnComments' in description column
       --showSchemaPrefix              show schema prefix in table name
       --useAllSchemas                 use all available schemas
       --useAllTables                  use all available tables
@@ -145,7 +145,9 @@ outputFileName: "my-db.mmd"
 debug: true
 omitConstraintLabels: true
 omitAttributeKeys: true
-showDescriptions: "columnComments"
+showDescriptions:
+  - enumValues
+  - columnComments
 showSchemaPrefix: true
 schemaPrefixSeparator: "_"
 ```
@@ -170,6 +172,9 @@ mermerd -c "postgresql://user:password@localhost:5432/yourDb" -s public --useAll
 
 # same as previous one, but use a list of tables without interaction
 mermerd -c "postgresql://user:password@localhost:5432/yourDb" -s public --selectedTables article,article_label
+
+# show enum values and column comments in the description column
+mermerd -c "postgresql://user:password@localhost:5432/yourDb" -s public --useAllTables --showDescriptions enumValues,columnComments
 ```
 
 ## Connection strings


### PR DESCRIPTION
Thanks for this amazing tool, it works flawlessly!

**Motivation**
We are using column comments in our Postgres database and want to keep these comments visible in the ER diagram.

**Solution**
I have made use of the additional column MermaidJS provides for general comments (see documentation for [MermaidJS erDiagram](https://mermaid.js.org/syntax/entityRelationshipDiagram.html#attribute-keys-and-comments)). In fact, you have already used this column for the `--showEnumValues` flag in #15.

My solution to support both features (1) column comments and (2) enum values is to replace `--showEnumValues` with e.g. `--showDescriptions enumValues,columnComments` which will render like this: 
![image](https://user-images.githubusercontent.com/33390735/230417800-11fd94d0-2994-48c6-8dbc-3306ca3938e2.png)


Note: to distinguish the comments from the enum types, I have surronded the enums with `<...>`.

**Known issue**
This solution will be a breaking change as the `--showEnumValues` flag will be replaced by `--showDescriptions enumValues`. I first thought about adding another flag e.g. `--showColumnComments` but didn't like the idea of having two flags interfering at the same location in the code. Furthermore, `--showDescriptions` now allows for quicker implementation of similar feature requests in the future.

**Feedback is welcome**
This is my first real PR and my first time using Go. If you have any concerns, improvements, suggestions, ... I am open to discussions and I am very happy to hear your feedback on this :)