### PR TITLE
Fix escaping of quote marks in descriptions

### DIFF
--- a/diagram/diagram_util.go
+++ b/diagram/diagram_util.go
@@ -2,9 +2,8 @@ package diagram
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/sirupsen/logrus"
+	"strings"
 
 	"github.com/KarnerTh/mermerd/config"
 	"github.com/KarnerTh/mermerd/database"
@@ -71,6 +70,9 @@ func getDescription(options []string, column database.ColumnResult) string {
 	return strings.TrimSpace(strings.Join(description, " "))
 }
 
+// escapeComments escapes invalid characters in comments.
+// mermaid does not support quote marks ("), as it uses this to mark the comment, as such these need to be replaced
+// with `#quot;`.
 func escapeComments(str string) string {
 	return strings.ReplaceAll(str, `"`, "#quot;")
 }

--- a/diagram/diagram_util.go
+++ b/diagram/diagram_util.go
@@ -2,8 +2,9 @@ package diagram
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/KarnerTh/mermerd/config"
 	"github.com/KarnerTh/mermerd/database"
@@ -62,12 +63,16 @@ func getDescription(options []string, column database.ColumnResult) string {
 				description = append(description, "<"+column.EnumValues+">")
 			}
 		case "columnComments":
-			description = append(description, column.Comment)
+			description = append(description, escapeComments(column.Comment))
 		default:
 			logrus.Errorf("Could not parse option %q", option)
 		}
 	}
 	return strings.TrimSpace(strings.Join(description, " "))
+}
+
+func escapeComments(str string) string {
+	return strings.ReplaceAll(str, `"`, "#quot;")
 }
 
 func shouldSkipConstraint(config config.MermerdConfig, tables []ErdTableData, constraint database.ConstraintResult) bool {

--- a/diagram/diagram_util_test.go
+++ b/diagram/diagram_util_test.go
@@ -128,7 +128,9 @@ func TestTableNameInSlice(t *testing.T) {
 func TestGetColumnData(t *testing.T) {
 	columnName := "testColumn"
 	enumValues := "a,b"
-	comment := "comment"
+	comment := `{"comment":"detail"}`
+	expectedComment := "{#quot;comment#quot;:#quot;detail#quot;}"
+
 	column := database.ColumnResult{
 		Name:       columnName,
 		IsPrimary:  true,
@@ -148,7 +150,7 @@ func TestGetColumnData(t *testing.T) {
 		// Assert
 		configMock.AssertExpectations(t)
 		assert.Equal(t, columnName, result.Name)
-		assert.Equal(t, "<"+enumValues+"> "+comment, result.Description)
+		assert.Equal(t, "<"+enumValues+"> "+expectedComment, result.Description)
 		assert.Equal(t, primaryKey, result.AttributeKey)
 	})
 
@@ -180,7 +182,7 @@ func TestGetColumnData(t *testing.T) {
 		// Assert
 		configMock.AssertExpectations(t)
 		assert.Equal(t, columnName, result.Name)
-		assert.Equal(t, comment, result.Description)
+		assert.Equal(t, expectedComment, result.Description)
 		assert.Equal(t, primaryKey, result.AttributeKey)
 	})
 
@@ -212,7 +214,7 @@ func TestGetColumnData(t *testing.T) {
 		// Assert
 		configMock.AssertExpectations(t)
 		assert.Equal(t, columnName, result.Name)
-		assert.Equal(t, "<"+enumValues+"> "+comment, result.Description)
+		assert.Equal(t, "<"+enumValues+"> "+expectedComment, result.Description)
 		assert.Equal(t, none, result.AttributeKey)
 	})
 


### PR DESCRIPTION
When a column comment contains a `"` mark then the outputted mermaid is invalid.

This change replaces the `"` with the `#quot;` string.

See failing output here: 
https://mermaid-js.github.io/mermaid-live-editor/edit#pako:eNo9jsEKwjAQRH8lzLlfkLOevAhe97J0Vw1tWkk2Yin5d1NbnNPweAyzop9F4aHpFPiRONLkWlgkac6a3bqDLaYfc0Hc9eIIK2HQheAJbx6LEiphdytN6BA1RQ7Stn8TBHtqbJpvVTgNm12bx8Xm2zL18JaKdigvYdPjDfydx_ynZwk2pwPWLzB8PeU

And correct here:
https://mermaid-js.github.io/mermaid-live-editor/edit#pako:eNo9jrEOwjAMRH8lMmu_IKwwsSCxZrFqA1GbBhynoqry76Sk4hafns4-r9BHYrDAcvL4EAxuMlVIJJwSJ7M2sEn5o8aTuV6Mg_XwzlGPAy_N2DZmHDM3Wxy03eIm6CCwBPRUu34nHeiTAzuw1RLKsKVLzWHWeFumHqxK5g7yi1B5_w7sHcf0p2fyGmWH5QveuESJ