### PR TITLE
allow not unique constraint name for postgres; add test

### DIFF
--- a/database/database_integration_test.go
+++ b/database/database_integration_test.go
@@ -116,6 +116,14 @@ func TestDatabaseIntegrations(t *testing.T) {
 					{Schema: schema, Name: "test_2_enum"},
 					{Schema: schema, Name: "test_3_a"},
 				}
+				if testCase.dbType == Postgres {
+					expectedResult = append(expectedResult, []TableDetail{
+						{Schema: schema, Name: "test_not_unique_constraint_name_a"},
+						{Schema: schema, Name: "test_not_unique_constraint_name_b"},
+						{Schema: schema, Name: "test_not_unique_constraint_name_c"},
+					}...)
+				}
+
 				assert.Nil(t, err)
 				assert.ElementsMatch(t, expectedResult, tables)
 			})
@@ -282,6 +290,15 @@ func TestDatabaseIntegrations(t *testing.T) {
 						{Schema: secondSchema, Name: "test_3_b"},
 						{Schema: secondSchema, Name: "test_3_c"},
 					}
+
+					if testCase.dbType == Postgres {
+						expectedResult = append(expectedResult, []TableDetail{
+							{Schema: testCase.schema, Name: "test_not_unique_constraint_name_a"},
+							{Schema: testCase.schema, Name: "test_not_unique_constraint_name_b"},
+							{Schema: testCase.schema, Name: "test_not_unique_constraint_name_c"},
+						}...)
+					}
+
 					assert.Nil(t, err)
 					assert.ElementsMatch(t, expectedResult, tables)
 				})

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -155,7 +155,8 @@ func (c *postgresConnector) GetConstraints(tableName TableDetail) ([]ConstraintR
 										on kc2.constraint_name = tc.constraint_name and
 										   tc.constraint_type = 'PRIMARY KEY'
 					where kc.constraint_name = c.constraint_name
-					  and kc.column_name = kcu.column_name)
+					  and kc.column_name = kcu.column_name
+            and kc.table_name = fk.table_name)
 			   , false) "isPrimary",
 		   (select COUNT(*) > 1 "hasMultiplePk"
 			from information_schema.table_constraints tc

--- a/database/postgres_test.go
+++ b/database/postgres_test.go
@@ -33,3 +33,24 @@ func TestPostgresEnums(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "apple,banana", enumValues)
 }
+
+func TestPostgresNotUniqueConstraintName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Arrange
+	tableName := TableDetail{Schema: "public", Name: "test_not_unique_constraint_name_b"}
+	connector, _ := NewConnectorFactory().NewConnector(testConnectionPostgres.connectionString)
+	if err := connector.Connect(); err != nil {
+		logrus.Error(err)
+		t.FailNow()
+	}
+
+	// Act
+	_, err := connector.GetConstraints(tableName)
+
+	// Assert
+	// we only need to check if an error is thrown
+	assert.Nil(t, err)
+}

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -12,6 +12,7 @@ services:
       - ./db-table-setup.sql:/docker-entrypoint-initdb.d/1.sql
       - ./postgres/postgres-enum-setup.sql:/docker-entrypoint-initdb.d/2.sql
       - ./postgres/postgres-multiple-databases.sql:/docker-entrypoint-initdb.d/3.sql
+      - ./postgres/postgres-not-unique-constraint-name.sql:/docker-entrypoint-initdb.d/4.sql
   mermerd-mysql-test-db:
     image: mysql:8.0
     command: --default-authentication-plugin=mysql_native_password

--- a/test/postgres/postgres-not-unique-constraint-name.sql
+++ b/test/postgres/postgres-not-unique-constraint-name.sql
@@ -1,0 +1,18 @@
+-- Test case for https://github.com/KarnerTh/mermerd/issues/36
+create table test_not_unique_constraint_name_a
+(
+    id int primary key
+);
+create table test_not_unique_constraint_name_b
+(
+    id int primary key
+);
+create table test_not_unique_constraint_name_c
+(
+    id int primary key
+);
+
+alter table test_not_unique_constraint_name_b 
+    add constraint not_unique_constraint_name foreign key (id) references test_not_unique_constraint_name_a (id);
+alter table test_not_unique_constraint_name_c 
+    add constraint not_unique_constraint_name foreign key (id) references test_not_unique_constraint_name_a (id);


### PR DESCRIPTION
fixes #36

take foreign table name of constraint into account for `isPrimary` column