### PR TITLE
Sort constraints.

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -207,6 +207,27 @@ func sortColumns(columns []database.ColumnResult) {
 
 func sortConstraints(constraints database.ConstraintResultList) {
 	sort.SliceStable(constraints, func(i, j int) bool {
+		if constraints[i].FkSchema != constraints[j].FkSchema {
+			return constraints[i].FkSchema < constraints[j].FkSchema
+		}
+		if constraints[i].FkTable != constraints[j].FkTable {
+			return constraints[i].FkTable < constraints[j].FkTable
+		}
+		if constraints[i].PkSchema != constraints[j].PkSchema {
+			return constraints[i].PkSchema < constraints[j].PkSchema
+		}
+		if constraints[i].PkTable != constraints[j].PkTable {
+			return constraints[i].PkTable < constraints[j].PkTable
+		}
+		if constraints[i].IsPrimary != constraints[j].IsPrimary {
+			return constraints[i].IsPrimary
+		}
+		if constraints[i].ColumnName != constraints[j].ColumnName {
+			return constraints[i].ColumnName < constraints[j].ColumnName
+		}
+		if constraints[i].HasMultiplePK != constraints[j].HasMultiplePK {
+			return constraints[i].HasMultiplePK
+		}
 		return constraints[i].ConstraintName < constraints[j].ConstraintName
 	})
 }

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -181,6 +181,7 @@ func (a analyzer) GetColumnsAndConstraints(db database.Connector, selectedTables
 		}
 
 		sortColumns(columns)
+		sortConstraints(constraints)
 		tableResults = append(tableResults, database.TableResult{Table: table, Columns: columns, Constraints: constraints})
 	}
 	a.loadingSpinner.Stop()
@@ -201,5 +202,11 @@ func getTableResultStats(tableResults []database.TableResult) (columnCount int, 
 func sortColumns(columns []database.ColumnResult) {
 	sort.SliceStable(columns, func(i, j int) bool {
 		return columns[i].Name < columns[j].Name
+	})
+}
+
+func sortConstraints(constraints database.ConstraintResultList) {
+	sort.SliceStable(constraints, func(i, j int) bool {
+		return constraints[i].ConstraintName < constraints[j].ConstraintName
 	})
 }

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -306,9 +306,10 @@ func TestAnalyzer_Analyze(t *testing.T) {
 		connectionFactoryMock.On("NewConnector", "validConnectionString").Return(&connectorMock, nil).Once()
 		connectorMock.On("Connect").Return(nil).Once()
 		connectorMock.On("Close").Return().Once()
-		configMock.On("Schemas").Return([]string{"schemaA"}).Once()
+		configMock.On("Schemas").Return([]string{"schemaA", "schemaB"}).Once()
 		// The tables returned are unsorted
 		configMock.On("SelectedTables").Return([]string{
+			"schemaB.tableB",
 			"schemaA.tableA",
 		}).Once()
 		connectorMock.On("GetColumns", database.TableDetail{Schema: "schemaA", Name: "tableA"}).Return([]database.ColumnResult{
@@ -316,14 +317,25 @@ func TestAnalyzer_Analyze(t *testing.T) {
 			{Name: "fieldC", DataType: "int"},
 			{Name: "fieldA", DataType: "int"},
 		}, nil).Once()
+		connectorMock.On("GetColumns", database.TableDetail{Schema: "schemaB", Name: "tableB"}).Return([]database.ColumnResult{
+			{Name: "fieldQ", DataType: "int"},
+			{Name: "fieldP", DataType: "int"},
+			{Name: "fieldR", DataType: "int"},
+		}, nil).Once()
+		// These constraints don't match the schema/table/columns. That's OK for this test - we're only testing the sorting.
 		connectorMock.On("GetConstraints", database.TableDetail{Schema: "schemaA", Name: "tableA"}).Return([]database.ConstraintResult{
-			{ConstraintName: "constraintB"},
-			{ConstraintName: "constraintC"},
-			{ConstraintName: "constraintA"},
+			{FkSchema: "schemaA", FkTable: "tableA", PkSchema: "schemaB", PkTable: "tableB", ConstraintName: "constraint7"},
+			{FkSchema: "schemaA", FkTable: "tableA", PkSchema: "schemaB", PkTable: "tableB", ConstraintName: "constraint6"},
+		}, nil).Once()
+		connectorMock.On("GetConstraints", database.TableDetail{Schema: "schemaB", Name: "tableB"}).Return([]database.ConstraintResult{
+			{FkSchema: "schemaB", FkTable: "tableB", PkSchema: "schemaA", PkTable: "tableA", ConstraintName: "constraint12"},
+			{FkSchema: "schemaB", FkTable: "tableB", PkSchema: "schemaB", PkTable: "tableB", ConstraintName: "constraint11"},
+			{FkSchema: "schemaB", FkTable: "tableB", PkSchema: "schemaA", PkTable: "tableA", ConstraintName: "constraint10"},
 		}, nil).Once()
 
 		// Act
 		result, err := analyzer.Analyze()
+		assert.Nil(t, err)
 
 		// Assert
 		configMock.AssertExpectations(t)
@@ -332,13 +344,50 @@ func TestAnalyzer_Analyze(t *testing.T) {
 		connectorMock.AssertExpectations(t)
 		assert.Nil(t, err)
 		assert.NotNil(t, result)
-		// The tables are now sorted
+		// The columns are now sorted
 		assert.Equal(t, result.Tables[0].Columns[0], database.ColumnResult{Name: "fieldA", DataType: "int"})
 		assert.Equal(t, result.Tables[0].Columns[1], database.ColumnResult{Name: "fieldB", DataType: "int"})
 		assert.Equal(t, result.Tables[0].Columns[2], database.ColumnResult{Name: "fieldC", DataType: "int"})
 
-		assert.Equal(t, result.Tables[0].Constraints[0], database.ConstraintResult{ConstraintName: "constraintA"})
-		assert.Equal(t, result.Tables[0].Constraints[1], database.ConstraintResult{ConstraintName: "constraintB"})
-		assert.Equal(t, result.Tables[0].Constraints[2], database.ConstraintResult{ConstraintName: "constraintC"})
+		assert.Equal(t, result.Tables[1].Columns[0], database.ColumnResult{Name: "fieldP", DataType: "int"})
+		assert.Equal(t, result.Tables[1].Columns[1], database.ColumnResult{Name: "fieldQ", DataType: "int"})
+		assert.Equal(t, result.Tables[1].Columns[2], database.ColumnResult{Name: "fieldR", DataType: "int"})
+
+		assert.Equal(t, result.Tables[0].Constraints[0], database.ConstraintResult{
+			FkSchema:       "schemaA",
+			FkTable:        "tableA",
+			PkSchema:       "schemaB",
+			PkTable:        "tableB",
+			ConstraintName: "constraint6",
+		})
+		assert.Equal(t, result.Tables[0].Constraints[1], database.ConstraintResult{
+			FkSchema:       "schemaA",
+			FkTable:        "tableA",
+			PkSchema:       "schemaB",
+			PkTable:        "tableB",
+			ConstraintName: "constraint7",
+		})
+
+		assert.Equal(t, result.Tables[1].Constraints[0], database.ConstraintResult{
+			FkSchema:       "schemaB",
+			FkTable:        "tableB",
+			PkSchema:       "schemaA",
+			PkTable:        "tableA",
+			ConstraintName: "constraint10",
+		})
+		assert.Equal(t, result.Tables[1].Constraints[1], database.ConstraintResult{
+			FkSchema:       "schemaB",
+			FkTable:        "tableB",
+			PkSchema:       "schemaA",
+			PkTable:        "tableA",
+			ConstraintName: "constraint12",
+		})
+		assert.Equal(t, result.Tables[1].Constraints[2], database.ConstraintResult{
+			FkSchema:       "schemaB",
+			FkTable:        "tableB",
+			PkSchema:       "schemaB",
+			PkTable:        "tableB",
+			ConstraintName: "constraint11",
+		})
 	})
 }


### PR DESCRIPTION
This is a fix for #44. I decided to sort by multiple struct fields, in the following order:

* `FkSchema`
* `FkTable`
* `PkSchema`
* `PkTable`
* `IsPrimary`
* `ColumnName`
* `HasMultiplePK`
* `ConstraintName`

This should ensure constraints are consistently sorted.

It would probably have been simpler to write a unit test for the `sortConstraints` function, but I went with the existing approach instead.