### PR TITLE
Quickfix for pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Start container with test databases
         run: docker-compose -f test/docker-compose.yaml up -d
+      - name: Wait for docker containers to start
+        run: sleep 30
       - name: Set up Go
         uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
Just a quickfix to wait for 30 seconds after starting docker containers - sqlserver seems to take some time.

Better solution would be to add/use some sort of healthcheck instead of waiting always 30 seconds