### PR TITLE
Addresses Issue #47: Update docs to handle special characters

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -197,6 +197,15 @@ Examples of valid connection strings:
 * `sqlserver://user:password@localhost:1433?database=yourDb` 
 * `sqlite3://mermerd_test.db`
 
+#### Special Characters
+Passwords with special characters may run into the "net/url: invalid userinfo" error. This can be worked around by percent encoding the characters
+
+| Invalid | Valid                                                        |
+|-----|----------------------------------------|
+|postgresql://user:password$@localhost:5432/yourDb|postgresql://user:password%24@localhost:5432/yourDb
+|postgresql://user:pass[];$/word@localhost:5432/yourDb|postgresql://user:pass%5B%5D%3B%24%2Fword@localhost:5432/yourDb
+
+
 ## How can I write/update Mermaid-JS diagrams?
 
 * All information can be found here: [Mermaid-JS](https://mermaid-js.github.io/mermaid/#/entityRelationshipDiagram)


### PR DESCRIPTION
Connections with non-standard characters fail with "net/url: invalid userinfo" due to the following change in database/sql, which added invalid characters for the connection string

PR: https://go-review.googlesource.com/c/go/+/87038
File: https://go-review.googlesource.com/c/go/+/88535/6/src/net/url/url.go

I was able to work around this by percent encoding any special characters in the connection string and updated with instructions in the readme. 

See this link for more conversions https://www.w3schools.com/tags/ref_urlencode.ASP