### PR TITLE
Start of considering unique and not null contraints.

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
       - "*"
+permissions:
+  contents: write
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/diagram/diagram.go
+++ b/diagram/diagram.go
@@ -57,7 +57,7 @@ func (d diagram) Create(wr io.Writer, result *database.Result) error {
 			continue
 		}
 
-		constraints = append(constraints, getConstraintData(d.config, relationshipLabelMap, constraint))
+		constraints = append(constraints, getConstraintData(d.config, relationshipLabelMap, result.Tables, constraint))
 	}
 
 	diagramData := ErdDiagramData{

--- a/diagram/diagram_data.go
+++ b/diagram/diagram_data.go
@@ -3,9 +3,10 @@ package diagram
 type ErdRelationType string
 
 const (
-	relationOneToOne      ErdRelationType = "|o--||"
-	relationOneToMaybeOne ErdRelationType = "|o--o|"
-	relationManyToOne     ErdRelationType = "}o--||"
+	relationOneToOne       ErdRelationType = "|o--||"
+	relationOneToMaybeOne  ErdRelationType = "|o--o|"
+	relationManyToOne      ErdRelationType = "}o--||"
+	relationManyToMaybeOne ErdRelationType = "}o--o|"
 )
 
 type ErdAttributeKey string

--- a/diagram/diagram_data.go
+++ b/diagram/diagram_data.go
@@ -3,8 +3,9 @@ package diagram
 type ErdRelationType string
 
 const (
-	relationOneToOne  ErdRelationType = "|o--||"
-	relationManyToOne ErdRelationType = "}o--||"
+	relationOneToOne      ErdRelationType = "|o--||"
+	relationOneToMaybeOne ErdRelationType = "|o--o|"
+	relationManyToOne     ErdRelationType = "}o--||"
 )
 
 type ErdAttributeKey string

--- a/diagram/diagram_util.go
+++ b/diagram/diagram_util.go
@@ -17,6 +17,8 @@ func getRelation(constraint database.ConstraintResult, isUnique bool, isNullable
 		return relationOneToMaybeOne
 	} else if isUnique {
 		return relationOneToOne
+	} else if isNullable {
+		return relationManyToMaybeOne
 	} else {
 		return relationManyToOne
 	}


### PR DESCRIPTION
This PR is a possible start to adding 2 new relations:
- relationOneToMaybeOne: `|o--o|`
- relationManyToMaybeOne: `}o--o|`

The code makes use of the `IsUnique` and `IsNullable` properties of `ColumnResult`, however, in its current form, it can't differentiate between one column being unique vs multiple columns being unique (`IsUnique` is true for both).