### PR TITLE
Fix PostgreSQL queries to handle duplicate constraint names across schemas

### DIFF
--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
       - ./postgres/postgres-enum-setup.sql:/docker-entrypoint-initdb.d/2.sql
       - ./postgres/postgres-multiple-databases.sql:/docker-entrypoint-initdb.d/3.sql
       - ./postgres/postgres-not-unique-constraint-name.sql:/docker-entrypoint-initdb.d/4.sql
+      - ./postgres/postgres-cross-schema-fk.sql:/docker-entrypoint-initdb.d/5.sql
   mermerd-mysql-test-db:
     image: mysql:8.0
     command: --default-authentication-plugin=mysql_native_password

--- a/test/postgres/postgres-cross-schema-fk.sql
+++ b/test/postgres/postgres-cross-schema-fk.sql
@@ -1,0 +1,22 @@
+-- Minimal test case for cross-schema FK bug
+-- Bug: GetConstraints() fails when multiple schemas have identically-named constraints
+-- Reproducer: Two schemas both have "users_pkey", cross-schema FK between them
+
+create schema tenant_1;
+create table tenant_1.users
+(
+    id int constraint users_pkey primary key
+);
+
+create schema tenant_2;
+create table tenant_2.users
+(
+    id int constraint users_pkey primary key
+);
+
+
+create table tenant_2.posts
+(
+    id         int primary key,
+    author_id  int references tenant_1.users(id)
+);


### PR DESCRIPTION
First, thanks for this lovely tool.

I have a multi-tenant setup where I use a PG schema per each tenant. This means I have the same constraint name repeated in different schemas. I was getting the following error:
```
ERROR: more than one row returned by a subquery used as an expression (SQLSTATE 21000)
```

So I added filtering by the schema in `GetConstraints` and `GetColumns`.